### PR TITLE
Various test fixes for Google import

### DIFF
--- a/src/http_template.cc
+++ b/src/http_template.cc
@@ -367,14 +367,14 @@ const char HttpTemplate::kWildCardPathPartKey[] = "*";
 
 const char HttpTemplate::kWildCardPathKey[] = "**";
 
-HttpTemplate *HttpTemplate::Parse(const std::string &ht) {
+std::unique_ptr<HttpTemplate> HttpTemplate::Parse(const std::string &ht) {
   Parser p(ht);
   if (!p.Parse() || !p.ValidateParts()) {
     return nullptr;
   }
 
-  return new HttpTemplate(std::move(p.segments()), std::move(p.verb()),
-                          std::move(p.variables()));
+  return std::unique_ptr<HttpTemplate>(new HttpTemplate(
+      std::move(p.segments()), std::move(p.verb()), std::move(p.variables())));
 }
 
 }  // namespace transcoding

--- a/src/include/grpc_transcoding/http_template.h
+++ b/src/include/grpc_transcoding/http_template.h
@@ -15,6 +15,7 @@
 #ifndef GRPC_TRANSCODING_HTTP_TEMPLATE_H_
 #define GRPC_TRANSCODING_HTTP_TEMPLATE_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -24,7 +25,7 @@ namespace transcoding {
 
 class HttpTemplate {
  public:
-  static HttpTemplate *Parse(const std::string &ht);
+  static std::unique_ptr<HttpTemplate> Parse(const std::string &ht);
   const std::vector<std::string> &segments() const { return segments_; }
   const std::string &verb() const { return verb_; }
 

--- a/test/http_template_test.cc
+++ b/test/http_template_test.cc
@@ -62,7 +62,7 @@ std::ostream &operator<<(std::ostream &os, const Variables &vars) {
 }
 
 TEST(HttpTemplate, ParseTest1) {
-  HttpTemplate *ht = HttpTemplate::Parse("/shelves/{shelf}/books/{book}");
+  auto ht = HttpTemplate::Parse("/shelves/{shelf}/books/{book}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"shelves", "*", "books", "*"}), ht->segments());
   ASSERT_EQ(Variables({
@@ -73,7 +73,7 @@ TEST(HttpTemplate, ParseTest1) {
 }
 
 TEST(HttpTemplate, ParseTest2) {
-  HttpTemplate *ht = HttpTemplate::Parse("/shelves/**");
+  auto ht = HttpTemplate::Parse("/shelves/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"shelves", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -81,7 +81,7 @@ TEST(HttpTemplate, ParseTest2) {
 }
 
 TEST(HttpTemplate, ParseTest3) {
-  HttpTemplate *ht = HttpTemplate::Parse("/**");
+  auto ht = HttpTemplate::Parse("/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -89,7 +89,7 @@ TEST(HttpTemplate, ParseTest3) {
 }
 
 TEST(HttpTemplate, ParseTest4a) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a:foo");
+  auto ht = HttpTemplate::Parse("/a:foo");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a"}), ht->segments());
   ASSERT_EQ("foo", ht->verb());
@@ -97,7 +97,7 @@ TEST(HttpTemplate, ParseTest4a) {
 }
 
 TEST(HttpTemplate, ParseTest4b) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/b/c:foo");
+  auto ht = HttpTemplate::Parse("/a/b/c:foo");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "b", "c"}), ht->segments());
   ASSERT_EQ("foo", ht->verb());
@@ -105,7 +105,7 @@ TEST(HttpTemplate, ParseTest4b) {
 }
 
 TEST(HttpTemplate, ParseTest5) {
-  HttpTemplate *ht = HttpTemplate::Parse("/*/**");
+  auto ht = HttpTemplate::Parse("/*/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -113,7 +113,7 @@ TEST(HttpTemplate, ParseTest5) {
 }
 
 TEST(HttpTemplate, ParseTest6) {
-  HttpTemplate *ht = HttpTemplate::Parse("/*/a/**");
+  auto ht = HttpTemplate::Parse("/*/a/**");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*", "a", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -121,7 +121,7 @@ TEST(HttpTemplate, ParseTest6) {
 }
 
 TEST(HttpTemplate, ParseTest7) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c}");
+  auto ht = HttpTemplate::Parse("/a/{a.b.c}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -132,7 +132,7 @@ TEST(HttpTemplate, ParseTest7) {
 }
 
 TEST(HttpTemplate, ParseTest8) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{a.b.c=*}");
+  auto ht = HttpTemplate::Parse("/a/{a.b.c=*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -143,7 +143,7 @@ TEST(HttpTemplate, ParseTest8) {
 }
 
 TEST(HttpTemplate, ParseTest9) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}");
+  auto ht = HttpTemplate::Parse("/a/{b=*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -154,7 +154,7 @@ TEST(HttpTemplate, ParseTest9) {
 }
 
 TEST(HttpTemplate, ParseTest10) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=**}");
+  auto ht = HttpTemplate::Parse("/a/{b=**}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -165,7 +165,7 @@ TEST(HttpTemplate, ParseTest10) {
 }
 
 TEST(HttpTemplate, ParseTest11) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/*}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "*"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -176,7 +176,7 @@ TEST(HttpTemplate, ParseTest11) {
 }
 
 TEST(HttpTemplate, ParseTest12) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/*/d}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/*/d}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "*", "d"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -187,7 +187,7 @@ TEST(HttpTemplate, ParseTest12) {
 }
 
 TEST(HttpTemplate, ParseTest13) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**}");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -198,7 +198,7 @@ TEST(HttpTemplate, ParseTest13) {
 }
 
 TEST(HttpTemplate, ParseTest14) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**}/d/e");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**}/d/e");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -209,7 +209,7 @@ TEST(HttpTemplate, ParseTest14) {
 }
 
 TEST(HttpTemplate, ParseTest15) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**/d}/e");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("", ht->verb());
@@ -220,7 +220,7 @@ TEST(HttpTemplate, ParseTest15) {
 }
 
 TEST(HttpTemplate, ParseTest16) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=c/**/d}/e:verb");
+  auto ht = HttpTemplate::Parse("/a/{b=c/**/d}/e:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"a", "c", "**", "d", "e"}), ht->segments());
   ASSERT_EQ("verb", ht->verb());
@@ -231,9 +231,7 @@ TEST(HttpTemplate, ParseTest16) {
 }
 
 TEST(HttpTemplate, CustomVerbTests) {
-  HttpTemplate *ht;
-
-  ht = HttpTemplate::Parse("/*:verb");
+  auto ht = HttpTemplate::Parse("/*:verb");
   ASSERT_EQ(Segments({"*"}), ht->segments());
   ASSERT_EQ(Variables(), ht->Variables());
 
@@ -265,7 +263,7 @@ TEST(HttpTemplate, CustomVerbTests) {
 }
 
 TEST(HttpTemplate, MoreVariableTests) {
-  HttpTemplate *ht = HttpTemplate::Parse("/{x}");
+  auto ht = HttpTemplate::Parse("/{x}");
 
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*"}), ht->segments());
@@ -357,7 +355,7 @@ TEST(HttpTemplate, MoreVariableTests) {
 }
 
 TEST(HttpTemplate, VariableAndCustomVerbTests) {
-  HttpTemplate *ht = HttpTemplate::Parse("/{x}:verb");
+  auto ht = HttpTemplate::Parse("/{x}:verb");
 
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(Segments({"*"}), ht->segments());
@@ -482,21 +480,21 @@ TEST(HttpTemplate, ErrorTests) {
 }
 
 TEST(HttpTemplate, ParseVerbTest2) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/*:verb");
+  auto ht = HttpTemplate::Parse("/a/*:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "*"}));
   ASSERT_EQ("verb", ht->verb());
 }
 
 TEST(HttpTemplate, ParseVerbTest3) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/**:verb");
+  auto ht = HttpTemplate::Parse("/a/**:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "**"}));
   ASSERT_EQ("verb", ht->verb());
 }
 
 TEST(HttpTemplate, ParseVerbTest4) {
-  HttpTemplate *ht = HttpTemplate::Parse("/a/{b=*}/**:verb");
+  auto ht = HttpTemplate::Parse("/a/{b=*}/**:verb");
   ASSERT_NE(nullptr, ht);
   ASSERT_EQ(ht->segments(), Segments({"a", "*", "**"}));
   ASSERT_EQ("verb", ht->verb());

--- a/test/message_stream_test.cc
+++ b/test/message_stream_test.cc
@@ -29,9 +29,6 @@ namespace transcoding {
 namespace testing {
 namespace {
 
-namespace pbio = ::google::protobuf::io;
-namespace pbutil = ::google::protobuf::util;
-
 // A test MessageStream implementation for testing ZeroCopyInputStream over
 // MessageStream implementation.
 class TestMessageStream : public MessageStream {
@@ -55,7 +52,9 @@ class TestMessageStream : public MessageStream {
     }
   }
   bool Finished() const { return messages_.empty() && finished_; }
-  pbutil::Status Status() const { return pbutil::Status::OK; }
+  google::protobuf::util::Status Status() const {
+    return google::protobuf::util::Status::OK;
+  }
 
  private:
   bool finished_;


### PR DESCRIPTION
- Use unique_ptr in HttpTemplate::Parse
- remove unused namespace remapping