### PR TITLE
Add gRPC frame error handling

### DIFF
--- a/src/include/grpc_transcoding/message_reader.h
+++ b/src/include/grpc_transcoding/message_reader.h
@@ -72,18 +72,22 @@ class MessageReader {
   //       NextMessage() again.
   std::unique_ptr<::google::protobuf::io::ZeroCopyInputStream> NextMessage();
 
+  ::google::protobuf::util::Status Status() const { return status_; }
+
   // Returns true if the stream has ended (this is permanent); otherwise returns
   // false.
-  bool Finished() const { return finished_; }
+  bool Finished() const { return finished_ || !status_.ok(); }
 
  private:
   TranscoderInputStream* in_;
   // The size of the current message.
-  unsigned int current_message_size_;
+  uint32_t current_message_size_;
   // Whether we have read the current message size or not
   bool have_current_message_size_;
   // Are we all done?
   bool finished_;
+  // Status
+  ::google::protobuf::util::Status status_;
 
   MessageReader(const MessageReader&) = delete;
   MessageReader& operator=(const MessageReader&) = delete;

--- a/src/include/grpc_transcoding/transcoder_input_stream.h
+++ b/src/include/grpc_transcoding/transcoder_input_stream.h
@@ -26,6 +26,9 @@ class TranscoderInputStream
  public:
   // returns the number of bytes available to read at the moment.
   virtual int64_t BytesAvailable() const = 0;
+
+  // returns if the stream is finished. i.e. No more data will be added.
+  virtual bool Finished() const = 0;
 };
 
 }  // namespace transcoding

--- a/src/message_stream.cc
+++ b/src/message_stream.cc
@@ -82,6 +82,8 @@ class InputStreamOverMessageStream : public TranscoderInputStream {
     return static_cast<int64_t>(message_.size() - position_);
   }
 
+  bool Finished() const { return src_->Finished(); }
+
  private:
   // Updates the current message and creates an ArrayInputStream over it.
   void ReadNextMessage() {

--- a/src/response_to_json_translator.cc
+++ b/src/response_to_json_translator.cc
@@ -44,8 +44,14 @@ bool ResponseToJsonTranslator::NextMessage(std::string* message) {
     // All done
     return false;
   }
+
   // Try to read a message
   auto proto_in = reader_.NextMessage();
+  status_ = reader_.Status();
+  if (!status_.ok()) {
+    return false;
+  }
+
   if (proto_in) {
     std::string json_out;
     if (TranslateMessage(proto_in.get(), &json_out)) {


### PR DESCRIPTION
in ESP, gRPC client handles those errors, but pure HTTP/2 proxy (Envoy, NGINX HTTP/2 upstream) doesn't.