### PR TITLE
Changed return of ByteCount() to use plain int64_t.

### DIFF
--- a/src/message_stream.cc
+++ b/src/message_stream.cc
@@ -71,7 +71,7 @@ class InputStreamOverMessageStream : public TranscoderInputStream {
 
   bool Skip(int) { return false; }  // Not implemented (no need)
 
-  google::protobuf::int64 ByteCount() const { return 0; }  // Not implemented
+  int64_t ByteCount() const { return 0; }  // Not implemented
 
   int64_t BytesAvailable() const {
     if (position_ >= message_.size()) {

--- a/test/test_common.h
+++ b/test/test_common.h
@@ -51,8 +51,8 @@ class TestZeroCopyInputStream : public TranscoderInputStream {
   bool Next(const void** data, int* size);
   void BackUp(int count);
   int64_t BytesAvailable() const;
-  ::google::protobuf::int64 ByteCount() const { return 0; }  // Not implemented
-  bool Skip(int) { return false; }                           // Not implemented
+  int64_t ByteCount() const { return 0; }  // Not implemented
+  bool Skip(int) { return false; }         // Not implemented
 
  private:
   std::deque<std::string> chunks_;


### PR DESCRIPTION
This is now consistent across all protobuf APIs.
It is no longer necessary to use the google::protobuf::int64 typedef.