### PR TITLE
Support full decoding of reserved expansions

### DIFF
--- a/src/include/grpc_transcoding/path_matcher.h
+++ b/src/include/grpc_transcoding/path_matcher.h
@@ -224,20 +224,23 @@ inline int hex_digit_to_int(char c) {
 // also return what character is escaped.
 bool GetEscapedChar(const std::string& src, size_t i,
                     UrlUnescapeSpec unescape_spec, char* out) {
-  const bool unescape_slash_char =
-      unescape_spec == UrlUnescapeSpec::kAllCharacters;
-  const bool unescape_reserved_chars =
-      (unescape_spec == UrlUnescapeSpec::kAllCharacters) ||
-      (unescape_spec == UrlUnescapeSpec::kAllCharactersExceptSlash);
   if (i + 2 < src.size() && src[i] == '%') {
     if (ascii_isxdigit(src[i + 1]) && ascii_isxdigit(src[i + 2])) {
       char c =
           (hex_digit_to_int(src[i + 1]) << 4) | hex_digit_to_int(src[i + 2]);
-      if (!unescape_slash_char && c == '/') {
-        return false;
-      }
-      if (!unescape_reserved_chars && c != '/' && IsReservedChar(c)) {
-        return false;
+      switch (unescape_spec) {
+        case UrlUnescapeSpec::kAllCharactersExceptReserved:
+          if (IsReservedChar(c)) {
+            return false;
+          }
+          break;
+        case UrlUnescapeSpec::kAllCharactersExceptSlash:
+          if (c == '/') {
+            return false;
+          }
+          break;
+        case UrlUnescapeSpec::kAllCharacters:
+          break;
       }
       *out = c;
       return true;

--- a/src/include/grpc_transcoding/path_matcher.h
+++ b/src/include/grpc_transcoding/path_matcher.h
@@ -151,7 +151,8 @@ class PathMatcherBuilder {
   std::unordered_set<std::string> custom_verbs_;
   typedef typename PathMatcher<Method>::MethodData MethodData;
   std::vector<std::unique_ptr<MethodData>> methods_;
-  UrlUnescapeSpec unescape_spec_;
+  UrlUnescapeSpec unescape_spec_ =
+      UrlUnescapeSpec::kAllCharactersExceptReserved;
 
   friend class PathMatcher<Method>;
 };
@@ -496,8 +497,7 @@ Method PathMatcher<Method>::Lookup(const std::string& http_method,
 // Initializes the builder with a root Path Segment
 template <class Method>
 PathMatcherBuilder<Method>::PathMatcherBuilder()
-    : root_ptr_(new PathMatcherNode()),
-      unescape_spec_(UrlUnescapeSpec::kAllCharactersExceptReserved) {}
+    : root_ptr_(new PathMatcherNode()) {}
 
 template <class Method>
 PathMatcherPtr<Method> PathMatcherBuilder<Method>::Build() {

--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -797,16 +797,6 @@ TEST_F(PathMatcherTest, VariableBindingsWithQueryParamsAndSystemParams) {
       bindings);
 }
 
-TEST(UrlUnescapeTest, SpecialCharacters) {
-  // EXPECT_EQ(UrlUnescapeString("%2523", true), "%23");
-  // EXPECT_EQ(UrlUnescapeString("%23", true), "#");
-  // EXPECT_EQ(UrlUnescapeString("%2523", false), "%23");
-  // EXPECT_EQ(UrlUnescapeString("%23", false), "%23");
-
-  // EXPECT_EQ(UrlUnescapeString("%252525", true), "%2525");
-  // EXPECT_EQ(UrlUnescapeString("%252525", false), "%2525");
-}
-
 }  // namespace
 
 }  // namespace transcoding

--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -116,11 +116,9 @@ class PathMatcherTest : public ::testing::Test {
 
   MethodInfo* AddGetPath(std::string path) { return AddPath("GET", path); }
 
-  void SetFullyDecodeReservedExpansion(bool value) {
-    builder_.SetFullyDecodeReservedExpansion(value);
+  void SetUrlUnescapeSpec(UrlUnescapeSpec unescape_spec) {
+    builder_.SetUrlUnescapeSpec(unescape_spec);
   }
-
-  void SetAlwaysDecode(bool value) { builder_.SetAlwaysDecode(value); }
 
   void Build() { matcher_ = builder_.Build(); }
 
@@ -383,31 +381,36 @@ TEST_F(PathMatcherTest, PercentEscapesNotUnescapedForMultiSegment2) {
             bindings);
 }
 
-TEST_F(PathMatcherTest, OnlyUnreservedCharsAreUnescapedForMultiSegmentMatch) {
+TEST_F(
+    PathMatcherTest,
+    OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchUnescapeAllExceptReservedImplicit) {
   // All %XX are reserved characters, they should be intact.
   MultiSegmentMatchWithReservedCharactersBase(
       "%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
 }
 
-TEST_F(PathMatcherTest,
-       OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchAlwaysDecode) {
-  SetFullyDecodeReservedExpansion(true);
-  // All %XX are reserved characters, they should be decoded.
+TEST_F(
+    PathMatcherTest,
+    OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchUnescapeAllExceptReservedExplicit) {
+  SetUrlUnescapeSpec(UrlUnescapeSpec::kAllCharactersExceptReserved);
+  // Set default value explicitly.
+  MultiSegmentMatchWithReservedCharactersBase(
+      "%21%23%24%26%27%28%29%2A%2B%2C%2F%3A%3B%3D%3F%40%5B%5D");
+}
+
+TEST_F(
+    PathMatcherTest,
+    OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchUnescapeAllExceptSlash) {
+  SetUrlUnescapeSpec(UrlUnescapeSpec::kAllCharactersExceptSlash);
+  // All %XX are reserved characters, all of them should be decoded except
+  // slash.
   MultiSegmentMatchWithReservedCharactersBase("!#$&'()*+,%2F:;=?@[]");
 }
 
 TEST_F(PathMatcherTest,
-       OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchFullyDecode) {
-  SetAlwaysDecode(true);
+       OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchUnescapeAll) {
+  SetUrlUnescapeSpec(UrlUnescapeSpec::kAllCharacters);
   // All %XX are reserved characters, they should be decoded.
-  MultiSegmentMatchWithReservedCharactersBase("!#$&'()*+,/:;=?@[]");
-}
-
-TEST_F(PathMatcherTest,
-       OnlyUnreservedCharsAreUnescapedForMultiSegmentMatchAlwaysAndFully) {
-  SetAlwaysDecode(true);
-  SetFullyDecodeReservedExpansion(true);
-  // AlwaysDecode wins.
   MultiSegmentMatchWithReservedCharactersBase("!#$&'()*+,/:;=?@[]");
 }
 


### PR DESCRIPTION
Implement underlying logic for `google.api.Http.fully_decode_reserved_expansion`.
Add a configurable option to always decode all path and query bindings.

Fixes #44 