### PR TITLE
Support unescape plus in query parameters

### DIFF
--- a/src/include/grpc_transcoding/path_matcher.h
+++ b/src/include/grpc_transcoding/path_matcher.h
@@ -234,10 +234,6 @@ inline int hex_digit_to_int(char c) {
 // If unescape_plus is true, unescape '+' to space.
 //
 // return value: 0: not unescaped, >0: unescaped, number of used original characters.
-// It can only be followings:
-// * 0: not unescaped, use the original character.
-// * 1: unescaped,  '+' -> space, only replace 1 original character.
-// * 3: unescaped percent-encoded "%HH" > c,  replaces 3 original characters.
 //
 int GetEscapedChar(const std::string& src, size_t i,
                    UrlUnescapeSpec unescape_spec, bool unescape_plus, char* out) {


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

To fix https://github.com/envoyproxy/envoy/issues/13965

Changes:
* add a config bool query_param_unescape_plus to unescape + in query parameters
* rename unescape_spec to path_unescape_spec since it only applies to path.
* config grpc_transcoder filter config will expose this flag.