### PR TITLE
Expose parsed gRPC message size

### DIFF
--- a/src/include/grpc_transcoding/message_reader.h
+++ b/src/include/grpc_transcoding/message_reader.h
@@ -34,6 +34,8 @@ constexpr size_t kGrpcDelimiterByteSize = 5;
 struct MessageAndGrpcFrame {
   std::unique_ptr<::google::protobuf::io::ZeroCopyInputStream> message;
   unsigned char grpc_frame[kGrpcDelimiterByteSize];
+  // The size (in bytes) of the full gRPC message, excluding the frame header.
+  uint32_t message_size;
 };
 
 // MessageReader helps extract full messages from a ZeroCopyInputStream of

--- a/src/message_reader.cc
+++ b/src/message_reader.cc
@@ -141,6 +141,7 @@ MessageAndGrpcFrame MessageReader::NextMessageAndGrpcFrame() {
   MessageAndGrpcFrame out;
   out.message = NextMessage();
   memcpy(out.grpc_frame, delimiter_, kGrpcDelimiterByteSize);
+  out.message_size = current_message_size_;
   return out;
 }
 

--- a/test/message_reader_test.cc
+++ b/test/message_reader_test.cc
@@ -115,6 +115,12 @@ class MessageReaderTestRun {
         EXPECT_EQ(delimiter_string, next_expected_->delimiter);
         return false;
       }
+      // Match the message size.
+      if (result.message_size != next_expected_->message.size()) {
+        EXPECT_EQ(
+            result.message_size, next_expected_->message.size());
+        return false;
+      }
       // Move to the next expected message
       ++next_expected_;
     }


### PR DESCRIPTION
We will use this to optimize gRPC resource extraction in consumers of this library.