### PR TITLE
b/208716168: allow path matcher to always check custom verb

### DIFF
--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -128,8 +128,8 @@ class PathMatcherTest : public ::testing::Test {
     builder_.SetQueryParamUnescapePlus(query_param_unescape_plus);
   }
 
-  void SetCheckUnregisteredCustomVerb(bool check_unregistered_custom_verb) {
-    builder_.SetCheckUnregisteredCustomVerb(check_unregistered_custom_verb);
+  void SetMatchUnregisteredCustomVerb(bool match_unregistered_custom_verb) {
+    builder_.SetMatchUnregisteredCustomVerb(match_unregistered_custom_verb);
   }
 
   void Build() { matcher_ = builder_.Build(); }
@@ -471,8 +471,8 @@ TEST_F(PathMatcherTest, CustomVerbIssue) {
 
 
 
-TEST_F(PathMatcherTest, CheckUnregisteredCustomVerb) {
-  SetCheckUnregisteredCustomVerb(true);
+TEST_F(PathMatcherTest, MatchUnregisteredCustomVerb) {
+  SetMatchUnregisteredCustomVerb(true);
   MethodInfo* get_person_1 = AddGetPath("/person/{id=*}");
   MethodInfo* get_person_2 = AddGetPath("/person/**");
   MethodInfo* get_person_3 = AddGetPath("/person/{id=*}/name");

--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -128,6 +128,10 @@ class PathMatcherTest : public ::testing::Test {
     builder_.SetQueryParamUnescapePlus(query_param_unescape_plus);
   }
 
+  void SetCheckUnregisteredCustomVerb(bool check_unregistered_custom_verb) {
+    builder_.SetCheckUnregisteredCustomVerb(check_unregistered_custom_verb);
+  }
+
   void Build() { matcher_ = builder_.Build(); }
 
   MethodInfo* LookupWithBodyFieldPath(std::string method, std::string path,
@@ -464,6 +468,45 @@ TEST_F(PathMatcherTest, CustomVerbIssue) {
   EXPECT_EQ(Lookup("GET", "/animal:other", &bindings), nullptr);
   EXPECT_EQ(Lookup("GET", "/animal/cat:other", &bindings), nullptr);
 }
+
+
+TEST_F(PathMatcherTest, CheckUnregisteredCustomVerb) {
+  SetCheckUnregisteredCustomVerb(true);
+  MethodInfo* get_person_1 = AddGetPath("/person/{id=*}");
+  MethodInfo* get_person_2 = AddGetPath("/person/**");
+  MethodInfo* get_person_3 = AddGetPath("/person/{id=*}/name");
+  MethodInfo* verb = AddGetPath("/{x=**}:verb");
+  Build();
+
+  EXPECT_NE(nullptr, get_person_1);
+  EXPECT_NE(nullptr, get_person_2);
+  EXPECT_NE(nullptr, verb);
+
+  Bindings bindings;
+  // with the verb
+  EXPECT_EQ(Lookup("GET", "/person:verb", &bindings), verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "person"}}), bindings);
+  EXPECT_EQ(Lookup("GET", "/person/jason:verb", &bindings), verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "person/jason"}}), bindings);
+
+    EXPECT_EQ(Lookup("GET", "/person/jason/name", &bindings), get_person_3);
+    // Path matcher doesn't do sanity check on the verb appearing in the middle segment.
+    EXPECT_EQ(Lookup("GET", "/person/jason:verb/name", &bindings), get_person_3);
+    EXPECT_EQ(Bindings({Binding{FieldPath{"id"}, "jason:verb"}}), bindings);
+
+  // with the verb but with a different prefix
+  EXPECT_EQ(Lookup("GET", "/animal:verb", &bindings), verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "animal"}}), bindings);
+  EXPECT_EQ(Lookup("GET", "/animal/cat:verb", &bindings), verb);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "animal/cat"}}), bindings);
+
+  // with a non-verb
+  EXPECT_EQ(Lookup("GET", "/person:other", &bindings), nullptr);
+  EXPECT_EQ(Lookup("GET", "/person/jason:other", &bindings), nullptr);
+  EXPECT_EQ(Lookup("GET", "/animal:other", &bindings), nullptr);
+  EXPECT_EQ(Lookup("GET", "/animal/cat:other", &bindings), nullptr);
+}
+
 
 TEST_F(PathMatcherTest, VariableBindingsWithCustomVerb) {
   MethodInfo* a_verb = AddGetPath("/a/{y=*}:verb");

--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -470,6 +470,7 @@ TEST_F(PathMatcherTest, CustomVerbIssue) {
 }
 
 
+
 TEST_F(PathMatcherTest, CheckUnregisteredCustomVerb) {
   SetCheckUnregisteredCustomVerb(true);
   MethodInfo* get_person_1 = AddGetPath("/person/{id=*}");
@@ -489,10 +490,11 @@ TEST_F(PathMatcherTest, CheckUnregisteredCustomVerb) {
   EXPECT_EQ(Lookup("GET", "/person/jason:verb", &bindings), verb);
   EXPECT_EQ(Bindings({Binding{FieldPath{"x"}, "person/jason"}}), bindings);
 
-    EXPECT_EQ(Lookup("GET", "/person/jason/name", &bindings), get_person_3);
-    // Path matcher doesn't do sanity check on the verb appearing in the middle segment.
-    EXPECT_EQ(Lookup("GET", "/person/jason:verb/name", &bindings), get_person_3);
-    EXPECT_EQ(Bindings({Binding{FieldPath{"id"}, "jason:verb"}}), bindings);
+  EXPECT_EQ(Lookup("GET", "/person/jason/name", &bindings), get_person_3);
+  // For the wrong-format url where the verb appears in the middle segment, the
+  // path matcher still regard it as a segment.
+  EXPECT_EQ(Lookup("GET", "/person/jason:verb/name", &bindings), get_person_3);
+  EXPECT_EQ(Bindings({Binding{FieldPath{"id"}, "jason:verb"}}), bindings);
 
   // with the verb but with a different prefix
   EXPECT_EQ(Lookup("GET", "/animal:verb", &bindings), verb);


### PR DESCRIPTION
Right now, the path matcher only match the registered custom verb. If it is unregistered and the trailing segment is wildcard, it will be part of that, causing a mismatch. For example,  `/foo/{x=*}` will matches `/foo/random:verb`, where `x` is bound to `random:verb`.

Add an option to always match the custom verb.