### PR TITLE
Add newline-delimited JSON response configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ bazel build //...
 $ bazel test //...
 ```
 
-Use the following script to check and fix code foramt:
+Use the following script to check and fix code format:
 
 ```bash
 $ script/check-style

--- a/src/include/grpc_transcoding/response_to_json_translator.h
+++ b/src/include/grpc_transcoding/response_to_json_translator.h
@@ -71,16 +71,19 @@ class ResponseToJsonTranslator : public MessageStream {
   // streaming - whether this is a streaming call or not
   // in - the input stream of delimited proto message(s) as in the gRPC wire
   //      format (http://www.grpc.io/docs/guides/wire.html)
-  // json_response_translate_options - control various aspects for the generated JSON, such
+  // json_response_translate_options - control various aspects for the generated
+  // JSON, such
   //      as indentation, whether to omit fields with default values,
-  //      etc through json_print_options (https://developers.google.com/protocol-buffers/docs/reference/cpp/
-  //      google.protobuf.util.json_util#JsonPrintOptions), and whether to omit the stream as newline-delimited
+  //      etc through json_print_options
+  //      (https://developers.google.com/protocol-buffers/docs/reference/cpp/
+  //      google.protobuf.util.json_util#JsonPrintOptions), and whether to omit
+  //      the stream as newline-delimited
   //      JSON or not
   ResponseToJsonTranslator(
       ::google::protobuf::util::TypeResolver* type_resolver,
       std::string type_url, bool streaming, TranscoderInputStream* in,
-      const JsonResponseTranslateOptions& json_response_translate_options =
-      { ::google::protobuf::util::JsonPrintOptions(), false });
+      const JsonResponseTranslateOptions& options = {
+          ::google::protobuf::util::JsonPrintOptions(), false});
 
   // MessageStream implementation
   bool NextMessage(std::string* message);
@@ -94,7 +97,7 @@ class ResponseToJsonTranslator : public MessageStream {
 
   ::google::protobuf::util::TypeResolver* type_resolver_;
   std::string type_url_;
-  JsonResponseTranslateOptions json_response_translate_options_;
+  const JsonResponseTranslateOptions options_;
   bool streaming_;
 
   // A MessageReader to extract full messages

--- a/src/include/grpc_transcoding/response_to_json_translator.h
+++ b/src/include/grpc_transcoding/response_to_json_translator.h
@@ -59,8 +59,17 @@ namespace transcoding {
 //       detect it and act appropriately.
 //
 
+// Control various aspects of the generated JSON during response translation
 struct JsonResponseTranslateOptions {
+  // JsonPrintOptions
+  // (https://developers.google.com/protocol-buffers/docs/reference/cpp/google.protobuf.util.json_util#JsonPrintOptions)
+  // to configures the printing of individual messages as JSON
   ::google::protobuf::util::JsonPrintOptions json_print_options;
+
+  // Whether the stream emits messages with newline-delimiters or not.
+  // If set to true, newline "\n" is used to separate streaming messages.
+  // If set to false, all streaming messages are treated as a JSON array and
+  // separated by comma.
   bool stream_newline_delimited;
 };
 
@@ -71,14 +80,7 @@ class ResponseToJsonTranslator : public MessageStream {
   // streaming - whether this is a streaming call or not
   // in - the input stream of delimited proto message(s) as in the gRPC wire
   //      format (http://www.grpc.io/docs/guides/wire.html)
-  // json_response_translate_options - control various aspects for the generated
-  // JSON, such
-  //      as indentation, whether to omit fields with default values,
-  //      etc through json_print_options
-  //      (https://developers.google.com/protocol-buffers/docs/reference/cpp/
-  //      google.protobuf.util.json_util#JsonPrintOptions), and whether to omit
-  //      the stream as newline-delimited
-  //      JSON or not
+  // options - control various aspects for the generated JSON
   ResponseToJsonTranslator(
       ::google::protobuf::util::TypeResolver* type_resolver,
       std::string type_url, bool streaming, TranscoderInputStream* in,

--- a/src/include/grpc_transcoding/response_to_json_translator.h
+++ b/src/include/grpc_transcoding/response_to_json_translator.h
@@ -58,6 +58,12 @@ namespace transcoding {
 //       an incomplete message at the end of the input. The callers will need to
 //       detect it and act appropriately.
 //
+
+struct JsonResponseTranslateOptions {
+  ::google::protobuf::util::JsonPrintOptions json_print_options;
+  bool stream_newline_delimited;
+};
+
 class ResponseToJsonTranslator : public MessageStream {
  public:
   // type_resolver - passed to BinaryToJsonStream() to do the translation
@@ -65,15 +71,16 @@ class ResponseToJsonTranslator : public MessageStream {
   // streaming - whether this is a streaming call or not
   // in - the input stream of delimited proto message(s) as in the gRPC wire
   //      format (http://www.grpc.io/docs/guides/wire.html)
-  // json_print_options - control various aspects for the generated JSON, such
-  //      as indentation, weather to omit fields with default values, etc (
-  //      https://developers.google.com/protocol-buffers/docs/reference/cpp/
-  //      google.protobuf.util.json_util#JsonPrintOptions
+  // json_response_translate_options - control various aspects for the generated JSON, such
+  //      as indentation, whether to omit fields with default values,
+  //      etc through json_print_options (https://developers.google.com/protocol-buffers/docs/reference/cpp/
+  //      google.protobuf.util.json_util#JsonPrintOptions), and whether to omit the stream as newline-delimited
+  //      JSON or not
   ResponseToJsonTranslator(
       ::google::protobuf::util::TypeResolver* type_resolver,
       std::string type_url, bool streaming, TranscoderInputStream* in,
-      const ::google::protobuf::util::JsonPrintOptions& json_print_options =
-          ::google::protobuf::util::JsonPrintOptions());
+      const JsonResponseTranslateOptions& json_response_translate_options =
+      { ::google::protobuf::util::JsonPrintOptions(), false });
 
   // MessageStream implementation
   bool NextMessage(std::string* message);
@@ -87,7 +94,7 @@ class ResponseToJsonTranslator : public MessageStream {
 
   ::google::protobuf::util::TypeResolver* type_resolver_;
   std::string type_url_;
-  const ::google::protobuf::util::JsonPrintOptions json_print_options_;
+  JsonResponseTranslateOptions json_response_translate_options_;
   bool streaming_;
 
   // A MessageReader to extract full messages

--- a/src/response_to_json_translator.cc
+++ b/src/response_to_json_translator.cc
@@ -26,14 +26,13 @@ namespace google {
 namespace grpc {
 
 namespace transcoding {
-
 ResponseToJsonTranslator::ResponseToJsonTranslator(
     ::google::protobuf::util::TypeResolver* type_resolver, std::string type_url,
     bool streaming, TranscoderInputStream* in,
-    const ::google::protobuf::util::JsonPrintOptions& json_print_options)
+    const JsonResponseTranslateOptions& json_response_translate_options)
     : type_resolver_(type_resolver),
       type_url_(std::move(type_url)),
-      json_print_options_(json_print_options),
+      json_response_translate_options_(json_response_translate_options),
       streaming_(streaming),
       reader_(in),
       first_(true),
@@ -67,9 +66,11 @@ bool ResponseToJsonTranslator::NextMessage(std::string* message) {
       return false;
     }
   } else if (streaming_ && reader_.Finished()) {
-    // This is a streaming call and the input is finished. Return the final ']'
-    // or "[]" in case this was an empty stream.
-    *message = first_ ? "[]" : "]";
+    if (!json_response_translate_options_.stream_newline_delimited) {
+      // This is a non-newline-delimited streaming call and the input is finished. Return the final ']'
+      // or "[]" in case this was an empty stream.
+      *message = first_ ? "[]" : "]";
+    }
     finished_ = true;
     return true;
   } else {
@@ -101,9 +102,9 @@ bool ResponseToJsonTranslator::TranslateMessage(
     std::string* json_out) {
   ::google::protobuf::io::StringOutputStream json_stream(json_out);
 
-  if (streaming_) {
+  if (streaming_ && !json_response_translate_options_.stream_newline_delimited) {
     if (first_) {
-      // This is a streaming call and this is the first message, so prepend the
+      // This is a non-newline-delimited streaming call and this is the first message, so prepend the
       // output JSON with a '['.
       if (!WriteChar(&json_stream, '[')) {
         status_ = ::google::protobuf::util::Status(
@@ -113,7 +114,7 @@ bool ResponseToJsonTranslator::TranslateMessage(
       }
       first_ = false;
     } else {
-      // For streaming calls add a ',' before each message except the first.
+      // For non-newline-delimited streaming calls add a ',' before each message except the first.
       if (!WriteChar(&json_stream, ',')) {
         status_ = ::google::protobuf::util::Status(
             ::google::protobuf::util::StatusCode::kInternal,
@@ -125,9 +126,20 @@ bool ResponseToJsonTranslator::TranslateMessage(
 
   // Do the actual translation.
   status_ = ::google::protobuf::util::BinaryToJsonStream(
-      type_resolver_, type_url_, proto_in, &json_stream, json_print_options_);
+      type_resolver_, type_url_, proto_in, &json_stream, json_response_translate_options_.json_print_options);
+
   if (!status_.ok()) {
     return false;
+  }
+
+  // Append a newline delimiter after the message if needed.
+  if (json_response_translate_options_.stream_newline_delimited) {
+    if (!WriteChar(&json_stream, '\n')) {
+        status_ = ::google::protobuf::util::Status(
+            ::google::protobuf::util::StatusCode::kInternal,
+            "Failed to build the response message.");
+        return false;
+    }
   }
 
   return true;

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -63,7 +63,8 @@ class ResponseToJsonTranslatorTestRun {
       : input_(input),
         expected_(expected),
         streaming_(streaming),
-        stream_newline_delimited_(json_response_translate_options.stream_newline_delimited),
+        stream_newline_delimited_(
+            json_response_translate_options.stream_newline_delimited),
         input_stream_(new TestZeroCopyInputStream()),
         translator_(new ResponseToJsonTranslator(
             type_resolver, type_url, streaming_, input_stream_.get(),
@@ -111,7 +112,8 @@ class ResponseToJsonTranslatorTestRun {
           if (!ExpectJsonObjectEq(next_expected_->json, actual)) {
             return false;
           }
-        } else if (!json_array_tester_.TestElement(next_expected_->json, actual)) {
+        } else if (!json_array_tester_.TestElement(next_expected_->json,
+                                                   actual)) {
           return false;
         }
       } else {
@@ -124,7 +126,8 @@ class ResponseToJsonTranslatorTestRun {
       ++next_expected_;
     }
     if (input_stream_->Finished() && streaming_) {
-      // In case of non-newline-delmited streaming calls if the input is finished, we expect the
+      // In case of non-newline-delmited streaming calls if the input is
+      // finished, we expect the
       // final ']' at the end of the stream.
 
       // Read the message
@@ -196,8 +199,8 @@ class ResponseToJsonTranslatorTestCase {
   ResponseToJsonTranslatorTestCase(
       pbutil::TypeResolver* type_resolver, bool streaming,
       const std::string& type_url,
-      const JsonResponseTranslateOptions& json_response_translate_options, std::string input,
-      std::vector<ExpectedAt> expected)
+      const JsonResponseTranslateOptions& json_response_translate_options,
+      std::string input, std::vector<ExpectedAt> expected)
       : type_resolver_(type_resolver),
         streaming_(streaming),
         type_url_(type_url),
@@ -207,9 +210,9 @@ class ResponseToJsonTranslatorTestCase {
 
   std::unique_ptr<ResponseToJsonTranslatorTestRun> NewRun() {
     return std::unique_ptr<ResponseToJsonTranslatorTestRun>(
-        new ResponseToJsonTranslatorTestRun(type_resolver_, streaming_,
-                                            type_url_, json_response_translate_options_,
-                                            input_, expected_));
+        new ResponseToJsonTranslatorTestRun(
+            type_resolver_, streaming_, type_url_,
+            json_response_translate_options_, input_, expected_));
   }
 
   // Runs the test for different partitions of the input.
@@ -256,7 +259,9 @@ class ResponseToJsonTranslatorTestCase {
 
 class ResponseToJsonTranslatorTest : public ::testing::Test {
  protected:
-  ResponseToJsonTranslatorTest() : streaming_(false), json_response_translate_options_({ pbutil::JsonPrintOptions(), false }) {}
+  ResponseToJsonTranslatorTest()
+      : streaming_(false),
+        json_response_translate_options_({pbutil::JsonPrintOptions(), false}) {}
 
   // Load the service config to be used for testing. This must be the first call
   // in a test.
@@ -273,10 +278,12 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
     type_url_ = "type.googleapis.com/" + type_name;
   }
 
-  // Sets whether to print the streaming response with newline delimiters or not.
+  // Sets whether to print the streaming response with newline delimiters or
+  // not.
   // Must be used before Build(). The default is false;
   void SetJsonStreamNewlineDelimited(bool stream_newline_delimited) {
-    json_response_translate_options_.stream_newline_delimited = stream_newline_delimited;
+    json_response_translate_options_.stream_newline_delimited =
+        stream_newline_delimited;
   }
 
   // Sets json print options type for used in this test. Must be used before
@@ -319,7 +326,8 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
     return std::unique_ptr<ResponseToJsonTranslatorTestCase>(
         new ResponseToJsonTranslatorTestCase(
             type_helper_->Resolver(), streaming_, type_url_,
-            json_response_translate_options_, std::move(input), std::move(expected)));
+            json_response_translate_options_, std::move(input),
+            std::move(expected)));
   }
 
  private:
@@ -802,7 +810,8 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
 
   TestZeroCopyInputStream input_stream;
   ResponseToJsonTranslator translator(
-      type_helper.Resolver(), "type.googleapis.com/Shelf", true, &input_stream, { pbutil::JsonPrintOptions(), true });
+      type_helper.Resolver(), "type.googleapis.com/Shelf", true, &input_stream,
+      {pbutil::JsonPrintOptions(), true});
 
   std::string message;
   // There is nothing translated
@@ -858,7 +867,6 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
   EXPECT_TRUE(translator.Finished());
   EXPECT_FALSE(translator.NextMessage(&message));
 }
-
 
 TEST_F(ResponseToJsonTranslatorTest, Streaming5KMessages) {
   // Load the service config

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -58,15 +58,16 @@ class ResponseToJsonTranslatorTestRun {
   ResponseToJsonTranslatorTestRun(
       pbutil::TypeResolver* type_resolver, bool streaming,
       const std::string& type_url,
-      const pbutil::JsonPrintOptions& json_print_options,
+      const JsonResponseTranslateOptions& json_response_translate_options,
       const std::string& input, const std::vector<ExpectedAt>& expected)
       : input_(input),
         expected_(expected),
         streaming_(streaming),
+        stream_newline_delimited_(json_response_translate_options.stream_newline_delimited),
         input_stream_(new TestZeroCopyInputStream()),
         translator_(new ResponseToJsonTranslator(
             type_resolver, type_url, streaming_, input_stream_.get(),
-            json_print_options)),
+            json_response_translate_options)),
         position_(0),
         next_expected_(std::begin(expected_)) {}
 
@@ -105,7 +106,12 @@ class ResponseToJsonTranslatorTestRun {
 
       // Match the message
       if (streaming_) {
-        if (!json_array_tester_.TestElement(next_expected_->json, actual)) {
+        // FIXME: handle newline-delimited case
+        if (stream_newline_delimited_) {
+          if (!ExpectJsonObjectEq(next_expected_->json, actual)) {
+            return false;
+          }
+        } else if (!json_array_tester_.TestElement(next_expected_->json, actual)) {
           return false;
         }
       } else {
@@ -118,7 +124,7 @@ class ResponseToJsonTranslatorTestRun {
       ++next_expected_;
     }
     if (input_stream_->Finished() && streaming_) {
-      // In case of streaming calls if the input is finished, we expect the
+      // In case of non-newline-delmited streaming calls if the input is finished, we expect the
       // final ']' at the end of the stream.
 
       // Read the message
@@ -162,6 +168,7 @@ class ResponseToJsonTranslatorTestRun {
   std::string input_;
   std::vector<ExpectedAt> expected_;
   bool streaming_;
+  bool stream_newline_delimited_;
 
   std::unique_ptr<TestZeroCopyInputStream> input_stream_;
   std::unique_ptr<ResponseToJsonTranslator> translator_;
@@ -189,19 +196,19 @@ class ResponseToJsonTranslatorTestCase {
   ResponseToJsonTranslatorTestCase(
       pbutil::TypeResolver* type_resolver, bool streaming,
       const std::string& type_url,
-      const pbutil::JsonPrintOptions& json_print_options, std::string input,
+      const JsonResponseTranslateOptions& json_response_translate_options, std::string input,
       std::vector<ExpectedAt> expected)
       : type_resolver_(type_resolver),
         streaming_(streaming),
         type_url_(type_url),
-        json_print_options_(json_print_options),
+        json_response_translate_options_(json_response_translate_options),
         input_(std::move(input)),
         expected_(std::move(expected)) {}
 
   std::unique_ptr<ResponseToJsonTranslatorTestRun> NewRun() {
     return std::unique_ptr<ResponseToJsonTranslatorTestRun>(
         new ResponseToJsonTranslatorTestRun(type_resolver_, streaming_,
-                                            type_url_, json_print_options_,
+                                            type_url_, json_response_translate_options_,
                                             input_, expected_));
   }
 
@@ -238,7 +245,7 @@ class ResponseToJsonTranslatorTestCase {
   pbutil::TypeResolver* type_resolver_;
   bool streaming_;
   std::string type_url_;
-  pbutil::JsonPrintOptions json_print_options_;
+  JsonResponseTranslateOptions json_response_translate_options_;
 
   // The entire input including message delimiters
   std::string input_;
@@ -249,7 +256,7 @@ class ResponseToJsonTranslatorTestCase {
 
 class ResponseToJsonTranslatorTest : public ::testing::Test {
  protected:
-  ResponseToJsonTranslatorTest() : streaming_(false) {}
+  ResponseToJsonTranslatorTest() : streaming_(false), json_response_translate_options_({ pbutil::JsonPrintOptions(), false }) {}
 
   // Load the service config to be used for testing. This must be the first call
   // in a test.
@@ -266,10 +273,16 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
     type_url_ = "type.googleapis.com/" + type_name;
   }
 
+  // Sets whether to print the streaming response with newline delimiters or not.
+  // Must be used before Build(). The default is false;
+  void SetJsonStreamNewlineDelimited(bool stream_newline_delimited) {
+    json_response_translate_options_.stream_newline_delimited = stream_newline_delimited;
+  }
+
   // Sets json print options type for used in this test. Must be used before
   // Build().
-  void SetJsonPrintOptions(const pbutil::JsonPrintOptions& json_print_options) {
-    json_print_options_ = json_print_options;
+  void SetJsonPrintOptions(pbutil::JsonPrintOptions json_print_options) {
+    json_response_translate_options_.json_print_options = json_print_options;
   }
 
   // Sets whether always print primitive fields for default values. Must be used
@@ -306,7 +319,7 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
     return std::unique_ptr<ResponseToJsonTranslatorTestCase>(
         new ResponseToJsonTranslatorTestCase(
             type_helper_->Resolver(), streaming_, type_url_,
-            json_print_options_, std::move(input), std::move(expected)));
+            json_response_translate_options_, std::move(input), std::move(expected)));
   }
 
  private:
@@ -314,7 +327,7 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
   std::unique_ptr<TypeHelper> type_helper_;
 
   std::string type_url_;
-  pbutil::JsonPrintOptions json_print_options_;
+  JsonResponseTranslateOptions json_response_translate_options_;
   bool streaming_;
 
   // The entire input
@@ -767,6 +780,85 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingDirectTest) {
   EXPECT_FALSE(translator.NextMessage(&message));
   EXPECT_TRUE(translator.Finished());
 }
+
+TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
+  // Load the service config
+  ::google::api::Service service;
+  ASSERT_TRUE(
+      transcoding::testing::LoadService("bookstore_service.pb.txt", &service));
+
+  // Create a TypeHelper using the service config
+  TypeHelper type_helper(service.types(), service.enums());
+
+  // Messages to test
+  auto test_message1 =
+      GenerateGrpcMessage<Shelf>(R"(name : "1" theme : "Fiction")");
+  auto test_message2 =
+      GenerateGrpcMessage<Shelf>(R"(name : "2" theme : "Fantasy")");
+  auto test_message3 =
+      GenerateGrpcMessage<Shelf>(R"(name : "3" theme : "Children")");
+  auto test_message4 =
+      GenerateGrpcMessage<Shelf>(R"(name : "4" theme : "Classics")");
+
+  TestZeroCopyInputStream input_stream;
+  ResponseToJsonTranslator translator(
+      type_helper.Resolver(), "type.googleapis.com/Shelf", true, &input_stream, { pbutil::JsonPrintOptions(), true });
+
+  std::string message;
+  // There is nothing translated
+  EXPECT_FALSE(translator.NextMessage(&message));
+
+  // Add test_message1 to the stream
+  input_stream.AddChunk(test_message1);
+
+  // Now we should have the test_message1 translated
+  EXPECT_TRUE(translator.NextMessage(&message));
+  EXPECT_TRUE(
+      ExpectJsonObjectEq(R"({ "name":"1", "theme":"Fiction" })", message));
+
+  // No more messages, but not finished yet
+  EXPECT_FALSE(translator.NextMessage(&message));
+  EXPECT_FALSE(translator.Finished());
+
+  // Add the test_message2, test_message3 and part of test_message4
+  input_stream.AddChunk(test_message2);
+  input_stream.AddChunk(test_message3);
+  input_stream.AddChunk(test_message4.substr(0, 10));
+
+  // Now we should have test_message2 & test_message3 translated
+  EXPECT_TRUE(translator.NextMessage(&message));
+  EXPECT_TRUE(
+      ExpectJsonObjectEq(R"({ "name":"2", "theme":"Fantasy" })", message));
+
+  EXPECT_TRUE(translator.NextMessage(&message));
+  EXPECT_TRUE(
+      ExpectJsonObjectEq(R"({ "name":"3", "theme":"Children" })", message));
+
+  // No more messages, but not finished yet
+  EXPECT_FALSE(translator.NextMessage(&message));
+  EXPECT_FALSE(translator.Finished());
+
+  // Add the rest of test_message4
+  input_stream.AddChunk(test_message4.substr(10));
+
+  // Now we should have the test_message4 translated
+  EXPECT_TRUE(translator.NextMessage(&message));
+  EXPECT_TRUE(
+      ExpectJsonObjectEq(R"({ "name":"4", "theme":"Classics" })", message));
+
+  // No more messages, but not finished yet
+  EXPECT_FALSE(translator.NextMessage(&message));
+  EXPECT_FALSE(translator.Finished());
+
+  // Now finish the stream
+  input_stream.Finish();
+
+  // All done!
+  EXPECT_TRUE(translator.NextMessage(&message));
+  EXPECT_TRUE(translator.Finished());
+  EXPECT_FALSE(translator.NextMessage(&message));
+}
+
 
 TEST_F(ResponseToJsonTranslatorTest, Streaming5KMessages) {
   // Load the service config

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -107,7 +107,6 @@ class ResponseToJsonTranslatorTestRun {
 
       // Match the message
       if (streaming_) {
-        // FIXME: handle newline-delimited case
         if (stream_newline_delimited_) {
           if (!ExpectJsonObjectEq(next_expected_->json, actual)) {
             return false;
@@ -824,6 +823,7 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
   EXPECT_TRUE(translator.NextMessage(&message));
   EXPECT_TRUE(
       ExpectJsonObjectEq(R"({ "name":"1", "theme":"Fiction" })", message));
+  EXPECT_TRUE(message.back() == '\n');
 
   // No more messages, but not finished yet
   EXPECT_FALSE(translator.NextMessage(&message));
@@ -838,10 +838,12 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
   EXPECT_TRUE(translator.NextMessage(&message));
   EXPECT_TRUE(
       ExpectJsonObjectEq(R"({ "name":"2", "theme":"Fantasy" })", message));
+  EXPECT_TRUE(message.back() == '\n');
 
   EXPECT_TRUE(translator.NextMessage(&message));
   EXPECT_TRUE(
       ExpectJsonObjectEq(R"({ "name":"3", "theme":"Children" })", message));
+  EXPECT_TRUE(message.back() == '\n');
 
   // No more messages, but not finished yet
   EXPECT_FALSE(translator.NextMessage(&message));
@@ -854,6 +856,7 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingNewlineDelimitedDirectTest) {
   EXPECT_TRUE(translator.NextMessage(&message));
   EXPECT_TRUE(
       ExpectJsonObjectEq(R"({ "name":"4", "theme":"Classics" })", message));
+  EXPECT_TRUE(message.back() == '\n');
 
   // No more messages, but not finished yet
   EXPECT_FALSE(translator.NextMessage(&message));


### PR DESCRIPTION
This PR is an implementation of newline-delimited JSON for streaming endpoints, as requested in #38. After this work is merged, it should be easier to implement JSON transcoding in a way that doesn't force consumers to wait for the end of a stream to collect messages as a single valid JSON array, allowing them to respond to each message individually.

Apologies in advance if I have committed any C++ sins, as it's been a while since I've used the language 🙏.