### PR TITLE
fix the script to format code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ $ bazel build //...
 $ bazel test //...
 ```
 
+Use the following script to check and code foramt:
+
+```bash
+$ script/check-style
+```
+
 ## Toolchain
 
 The Bazel build system defaults to using clang 10 to enable reproducible builds.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ $ bazel build //...
 $ bazel test //...
 ```
 
-Use the following script to check and code foramt:
+Use the following script to check and fix code foramt:
 
 ```bash
 $ script/check-style

--- a/script/check-style
+++ b/script/check-style
@@ -28,7 +28,7 @@ if [[ "${CLANG_VERSION}" != "${CLANG_VERSION_REQUIRED}" ]]; then
   echo "Installing required clang-format ${CLANG_VERSION_REQUIRED} to ${CLANG_DIRECTORY}"
   mkdir -p ${CLANG_DIRECTORY}
   curl --silent --show-error --retry 10 \
-    "http://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-x86_64-linux-gnu-ubuntu-14.04.tar.xz" \
+    "https://releases.llvm.org/${CLANG_VERSION_REQUIRED}/clang+llvm-${CLANG_VERSION_REQUIRED}-x86_64-linux-gnu-ubuntu-14.04.tar.xz" \
     | tar Jx -C "${CLANG_DIRECTORY}" --strip=1 \
   || { echo "Could not install required clang-format. Skip formating." ; exit 0 ; }
 fi

--- a/src/include/grpc_transcoding/percent_encoding.h
+++ b/src/include/grpc_transcoding/percent_encoding.h
@@ -15,9 +15,8 @@
 #ifndef GRPC_TRANSCODING_PERCENT_ENCODING_H_
 #define GRPC_TRANSCODING_PERCENT_ENCODING_H_
 
-#include "absl/strings/string_view.h"
 #include <string>
-
+#include "absl/strings/string_view.h"
 
 namespace google {
 namespace grpc {
@@ -34,7 +33,6 @@ enum class UrlUnescapeSpec {
   // URL path parameters will be fully URI-decoded.
   kAllCharacters,
 };
-
 
 inline bool IsReservedChar(char c) {
   // Reserved characters according to RFC 6570
@@ -96,8 +94,8 @@ inline int hex_digit_to_int(char c) {
 // characters.
 //
 inline int GetEscapedChar(absl::string_view src, size_t i,
-                   UrlUnescapeSpec unescape_spec, bool unescape_plus,
-                   char* out) {
+                          UrlUnescapeSpec unescape_spec, bool unescape_plus,
+                          char* out) {
   if (unescape_plus && src[i] == '+') {
     *out = ' ';
     return 1;
@@ -128,7 +126,8 @@ inline int GetEscapedChar(absl::string_view src, size_t i,
 }
 
 inline bool IsUrlEscapedString(absl::string_view part,
-                               UrlUnescapeSpec unescape_spec, bool unescape_plus) {
+                               UrlUnescapeSpec unescape_spec,
+                               bool unescape_plus) {
   char ch = '\0';
   for (size_t i = 0; i < part.size(); ++i) {
     if (GetEscapedChar(part, i, unescape_spec, unescape_plus, &ch) > 0) {
@@ -141,7 +140,6 @@ inline bool IsUrlEscapedString(absl::string_view part,
 inline bool IsUrlEscapedString(absl::string_view part) {
   return IsUrlEscapedString(part, UrlUnescapeSpec::kAllCharacters, false);
 }
-
 
 // Unescapes string 'part' and returns the unescaped string. Reserved characters
 // (as specified in RFC 6570) are not escaped if unescape_reserved_chars is
@@ -179,7 +177,6 @@ inline std::string UrlUnescapeString(absl::string_view part,
 inline std::string UrlUnescapeString(absl::string_view part) {
   return UrlUnescapeString(part, UrlUnescapeSpec::kAllCharacters, false);
 }
-
 
 }  // namespace transcoding
 }  // namespace grpc

--- a/src/include/grpc_transcoding/request_weaver.h
+++ b/src/include/grpc_transcoding/request_weaver.h
@@ -78,7 +78,9 @@ class RequestWeaver : public google::protobuf::util::converter::ObjectWriter {
                 google::protobuf::util::converter::ObjectWriter* ow,
                 StatusErrorListener* el, bool report_collisions);
 
-  ::google::protobuf::util::Status Status() { return error_listener_->status(); }
+  ::google::protobuf::util::Status Status() {
+    return error_listener_->status();
+  }
 
   // ObjectWriter methods
   RequestWeaver* StartObject(internal::string_view name);
@@ -133,8 +135,9 @@ class RequestWeaver : public google::protobuf::util::converter::ObjectWriter {
 
   // Checks if any repeated fields with the same field name are in the current
   // node of the weave tree. Output them if there are any.
-  void CollisionCheck(internal::string_view name,
-                      const ::google::protobuf::util::converter::DataPiece& value);
+  void CollisionCheck(
+      internal::string_view name,
+      const ::google::protobuf::util::converter::DataPiece& value);
 
   // All the headers, variable bindings and parameter bindings to be weaved in.
   //   root_   : root of the tree to be weaved in.

--- a/src/include/grpc_transcoding/status_error_listener.h
+++ b/src/include/grpc_transcoding/status_error_listener.h
@@ -1,8 +1,8 @@
 #ifndef GRPC_TRANSCODING_STATUS_ERROR_LISTENER_H_
 #define GRPC_TRANSCODING_STATUS_ERROR_LISTENER_H_
 
-#include "grpc_transcoding/internal/protobuf_types.h"
 #include "google/protobuf/util/internal/error_listener.h"
+#include "grpc_transcoding/internal/protobuf_types.h"
 
 namespace google {
 namespace grpc {
@@ -10,7 +10,8 @@ namespace grpc {
 namespace transcoding {
 
 // StatusErrorListener converts the error events into a Status
-class StatusErrorListener : public ::google::protobuf::util::converter::ErrorListener  {
+class StatusErrorListener
+    : public ::google::protobuf::util::converter::ErrorListener {
  public:
   StatusErrorListener() {}
   virtual ~StatusErrorListener() {}
@@ -31,7 +32,7 @@ class StatusErrorListener : public ::google::protobuf::util::converter::ErrorLis
   void set_status(::google::protobuf::util::Status status) { status_ = status; }
 
  private:
-  ::google::protobuf::util::Status  status_;
+  ::google::protobuf::util::Status status_;
 
   GOOGLE_DISALLOW_EVIL_CONSTRUCTORS(StatusErrorListener);
 };

--- a/src/include/grpc_transcoding/type_helper.h
+++ b/src/include/grpc_transcoding/type_helper.h
@@ -75,8 +75,9 @@ class TypeHelper {
   void AddType(const ::google::protobuf::Type& t);
   void AddEnum(const ::google::protobuf::Enum& e);
 
-  const google::protobuf::Field* FindField(const google::protobuf::Type* type,
-                                           google::protobuf::StringPiece name) const;
+  const google::protobuf::Field* FindField(
+      const google::protobuf::Type* type,
+      google::protobuf::StringPiece name) const;
 
   ::google::protobuf::util::TypeResolver* type_resolver_;
   std::unique_ptr<::google::protobuf::util::converter::TypeInfo> type_info_;

--- a/src/message_reader.cc
+++ b/src/message_reader.cc
@@ -85,8 +85,8 @@ std::unique_ptr<pbio::ZeroCopyInputStream> MessageReader::NextMessage() {
 
   // Check if we have the current message size. If not try to read it.
   if (!have_current_message_size_) {
-    if (in_->BytesAvailable()
-        < static_cast<pb::int64>(kGrpcDelimiterByteSize)) {
+    if (in_->BytesAvailable() <
+        static_cast<pb::int64>(kGrpcDelimiterByteSize)) {
       // We don't have 5 bytes available to read the length of the message.
       // Find out whether the stream is finished and return false.
       finished_ = in_->Finished();

--- a/src/request_stream_translator.cc
+++ b/src/request_stream_translator.cc
@@ -87,8 +87,8 @@ RequestStreamTranslator* RequestStreamTranslator::EndObject() {
   }
   --depth_;
   if (depth_ < 1) {
-    status_ =
-        pbutil::Status(pbutil::StatusCode::kInvalidArgument, "Mismatched end of object.");
+    status_ = pbutil::Status(pbutil::StatusCode::kInvalidArgument,
+                             "Mismatched end of object.");
     return this;
   }
   translator_->Input().EndObject();
@@ -129,8 +129,8 @@ RequestStreamTranslator* RequestStreamTranslator::EndList() {
   }
   --depth_;
   if (depth_ < 0) {
-    status_ =
-        pbutil::Status(pbutil::StatusCode::kInvalidArgument, "Mismatched end of array.");
+    status_ = pbutil::Status(pbutil::StatusCode::kInvalidArgument,
+                             "Mismatched end of array.");
     return this;
   }
   if (depth_ == 0) {
@@ -251,7 +251,8 @@ void RequestStreamTranslator::EndMessageTranslator() {
   } else {
     // This shouldn't happen unless something like StartList(), StartObject(),
     // EndList() has been called
-    status_ = pbutil::Status(pbutil::StatusCode::kInvalidArgument, "Invalid object");
+    status_ =
+        pbutil::Status(pbutil::StatusCode::kInvalidArgument, "Invalid object");
   }
   translator_.reset();
 }

--- a/src/request_weaver.cc
+++ b/src/request_weaver.cc
@@ -43,8 +43,7 @@ pb::util::Status bindingFailureStatus(internal::string_view field_name,
   return pb::util::Status(
       pb::util::StatusCode::kInvalidArgument,
       pb::StrCat("Failed to convert binding value ", field_name, ":",
-                 value.ValueAsStringOrDefault(""),
-                 " to ", type));
+                 value.ValueAsStringOrDefault(""), " to ", type));
 }
 
 pb::util::Status isEqual(internal::string_view field_name,
@@ -97,9 +96,8 @@ pb::util::Status isEqual(internal::string_view field_name,
       if (!status.ok()) {
         return bindingFailureStatus(field_name, "double", value_in_binding);
       }
-      if (!pb::MathUtil::AlmostEquals<double>(status.value(),
-                                              value_in_body.ToDouble().value())) {
-
+      if (!pb::MathUtil::AlmostEquals<double>(
+              status.value(), value_in_body.ToDouble().value())) {
         value_is_same = false;
       }
       break;
@@ -145,14 +143,16 @@ pb::util::Status isEqual(internal::string_view field_name,
       }
       break;
     }
-    default:break;
+    default:
+      break;
   }
   if (!value_is_same) {
     return pb::util::Status(
         pb::util::StatusCode::kInvalidArgument,
         absl::StrFormat("The binding value %s of the field %s is "
                         "conflicting with the value %s in the body.",
-                        value_in_binding.ValueAsStringOrDefault(""), std::string(field_name),
+                        value_in_binding.ValueAsStringOrDefault(""),
+                        std::string(field_name),
                         value_in_body.ValueAsStringOrDefault("")));
   }
   return pb::util::OkStatus();
@@ -161,15 +161,15 @@ pb::util::Status isEqual(internal::string_view field_name,
 }  // namespace
 
 RequestWeaver::RequestWeaver(std::vector<BindingInfo> bindings,
-                             pbconv::ObjectWriter* ow,
-                             StatusErrorListener* el, bool report_collisions)
+                             pbconv::ObjectWriter* ow, StatusErrorListener* el,
+                             bool report_collisions)
     : root_(),
       current_(),
       ow_(ow),
       non_actionable_depth_(0),
       error_listener_(el),
       report_collisions_(report_collisions) {
-  for (const auto& b: bindings) {
+  for (const auto& b : bindings) {
     Bind(std::move(b.field_path), std::move(b.value));
   }
 }
@@ -330,13 +330,13 @@ void RequestWeaver::Bind(std::vector<const pb::Field*> field_path,
 }
 
 void RequestWeaver::WeaveTree(RequestWeaver::WeaveInfo* info) {
-  for (const auto& data: info->bindings) {
+  for (const auto& data : info->bindings) {
     pbconv::ObjectWriter::RenderDataPieceTo(
         pbconv::DataPiece(internal::string_view(data.second), true),
         internal::string_view(data.first->name()), ow_);
   }
   info->bindings.clear();
-  for (auto& msg: info->messages) {
+  for (auto& msg : info->messages) {
     // Enter into the message only if there are bindings or submessages left
     if (!msg.second.bindings.empty() || !msg.second.messages.empty()) {
       ow_->StartObject(msg.first->name());

--- a/src/type_helper.cc
+++ b/src/type_helper.cc
@@ -21,10 +21,10 @@
 
 #include "absl/strings/str_split.h"
 #include "absl/synchronization/mutex.h"
-#include "grpc_transcoding/percent_encoding.h"
 #include "google/protobuf/type.pb.h"
 #include "google/protobuf/util/internal/type_info.h"
 #include "google/protobuf/util/type_resolver.h"
+#include "grpc_transcoding/percent_encoding.h"
 
 namespace pbutil = ::google::protobuf::util;
 namespace pbconv = ::google::protobuf::util::converter;
@@ -184,7 +184,8 @@ pbutil::Status TypeHelper::ResolveFieldPath(
 }
 
 const google::protobuf::Field* TypeHelper::FindField(
-    const google::protobuf::Type* type, google::protobuf::StringPiece name) const {
+    const google::protobuf::Type* type,
+    google::protobuf::StringPiece name) const {
   auto* field = Info()->FindField(type, name);
   if (field != nullptr) {
     return field;

--- a/test/http_template_fuzz_test.cc
+++ b/test/http_template_fuzz_test.cc
@@ -1,11 +1,11 @@
 #include "grpc_transcoding/http_template.h"
 
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
-  std::string path((const char*)data, size);
+  std::string path((const char *)data, size);
   google::grpc::transcoding::HttpTemplate::Parse(path);
   return 0;
 }

--- a/test/json_request_translator_test.cc
+++ b/test/json_request_translator_test.cc
@@ -484,7 +484,8 @@ TEST_F(JsonRequestTranslatorTest, ErrorInvalidJson) {
       AddChunk(invalid);
       Finish();
       EXPECT_TRUE(Tester().ExpectNone());
-      EXPECT_TRUE(Tester().ExpectStatusEq(google::protobuf::util::StatusCode::kInvalidArgument));
+      EXPECT_TRUE(Tester().ExpectStatusEq(
+          google::protobuf::util::StatusCode::kInvalidArgument));
     }
   }
 }
@@ -733,7 +734,8 @@ TEST_F(JsonRequestTranslatorTest, StreamingErrorNotAnArray) {
   AddChunk(R"({"name" : "1"})");
   Finish();
   EXPECT_TRUE(Tester().ExpectNone());
-  EXPECT_TRUE(Tester().ExpectStatusEq(google::protobuf::util::StatusCode::kInvalidArgument));
+  EXPECT_TRUE(Tester().ExpectStatusEq(
+      google::protobuf::util::StatusCode::kInvalidArgument));
 }
 
 }  // namespace

--- a/test/message_reader_fuzz_test.cc
+++ b/test/message_reader_fuzz_test.cc
@@ -3,8 +3,8 @@
 #include "test_common.h"
 
 #include <fuzzer/FuzzedDataProvider.h>
-#include <cstdint>
 #include <cstddef>
+#include <cstdint>
 #include <string>
 
 namespace google {
@@ -20,14 +20,13 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
   MessageReader reader(&input_stream);
 
   while (provider.remaining_bytes() > 0) {
-
     // Add a few chucks of data to the input stream.
     for (int i = 0; i < provider.ConsumeIntegralInRange(0, 5); i++) {
       input_stream.AddChunk(provider.ConsumeRandomLengthString(100));
     }
 
     // Run the message reader to get the next message.
-    (void) reader.NextMessageAndGrpcFrame();
+    (void)reader.NextMessageAndGrpcFrame();
 
     // Handle end of input or error due to malformed bytes.
     if (reader.Finished()) {
@@ -37,7 +36,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
 
   return 0;
 }
-
 }
 }
 }

--- a/test/message_reader_test.cc
+++ b/test/message_reader_test.cc
@@ -88,7 +88,7 @@ class MessageReaderTestRun {
     // While we still have expected messages before or at the current position
     // try to match.
     while (next_expected_ != std::end(expected_) &&
-        next_expected_->at <= position_) {
+           next_expected_->at <= position_) {
       // Must not be finished as we expect a message
       if (reader_->Finished()) {
         ADD_FAILURE() << "Finished unexpectedly" << std::endl;
@@ -117,8 +117,7 @@ class MessageReaderTestRun {
       }
       // Match the message size.
       if (result.message_size != next_expected_->message.size()) {
-        EXPECT_EQ(
-            result.message_size, next_expected_->message.size());
+        EXPECT_EQ(result.message_size, next_expected_->message.size());
         return false;
       }
       // Move to the next expected message
@@ -165,8 +164,8 @@ class MessageReaderTestCase {
       input_ += message;
       // Remember that we should expect this message after input_.size() bytes
       // are processed.
-      expected_.emplace_back(ExpectedAt{input_.size(), message,
-                                        SizeToDelimiter(message.size())});
+      expected_.emplace_back(
+          ExpectedAt{input_.size(), message, SizeToDelimiter(message.size())});
     }
   }
 
@@ -390,8 +389,7 @@ TEST_F(MessageReaderTest, IncompleteFrameHeader) {
 
   EXPECT_EQ(nullptr, reader.NextMessage().get());
   EXPECT_FALSE(reader.Status().ok());
-  EXPECT_EQ(reader.Status().message(),
-            "Incomplete gRPC frame header received");
+  EXPECT_EQ(reader.Status().message(), "Incomplete gRPC frame header received");
 }
 
 TEST_F(MessageReaderTest, InvalidFrameFlag) {

--- a/test/path_matcher_test.cc
+++ b/test/path_matcher_test.cc
@@ -469,8 +469,6 @@ TEST_F(PathMatcherTest, CustomVerbIssue) {
   EXPECT_EQ(Lookup("GET", "/animal/cat:other", &bindings), nullptr);
 }
 
-
-
 TEST_F(PathMatcherTest, MatchUnregisteredCustomVerb) {
   SetMatchUnregisteredCustomVerb(true);
   MethodInfo* get_person_1 = AddGetPath("/person/{id=*}");
@@ -508,7 +506,6 @@ TEST_F(PathMatcherTest, MatchUnregisteredCustomVerb) {
   EXPECT_EQ(Lookup("GET", "/animal:other", &bindings), nullptr);
   EXPECT_EQ(Lookup("GET", "/animal/cat:other", &bindings), nullptr);
 }
-
 
 TEST_F(PathMatcherTest, VariableBindingsWithCustomVerb) {
   MethodInfo* a_verb = AddGetPath("/a/{y=*}:verb");
@@ -879,7 +876,8 @@ TEST_F(PathMatcherTest, QueryParameterNotUnescapePlus) {
   Bindings bindings;
   // The bindings from the query parameters "x=Hello+world&y=%2B+%20"
   // By default, only unescape percent-encoded %HH,  but not '+'
-  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello+world&y=%2B+%20", &bindings), a);
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello+world&y=%2B+%20", &bindings),
+            a);
   EXPECT_EQ(Bindings({
                 Binding{FieldPath{"x"}, "Hello+world"},
                 Binding{FieldPath{"y"}, "++ "},
@@ -898,7 +896,8 @@ TEST_F(PathMatcherTest, QueryParameterUnescapePlus) {
   Bindings bindings;
   // The bindings from the query parameters "x=Hello+world&y=%2B+%20"
   // Unescape percent-encoded %HH, and convert '+' to space
-  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello+world&y=%2B+%20", &bindings), a);
+  EXPECT_EQ(LookupWithParams("GET", "/a", "x=Hello+world&y=%2B+%20", &bindings),
+            a);
   EXPECT_EQ(Bindings({
                 Binding{FieldPath{"x"}, "Hello world"},
                 Binding{FieldPath{"y"}, "+  "},

--- a/test/proto_stream_tester.cc
+++ b/test/proto_stream_tester.cc
@@ -98,12 +98,14 @@ bool ProtoStreamTester::ValidateDelimiter(const std::string& message) {
   return true;
 }
 
-bool ProtoStreamTester::ExpectStatusEq(google::protobuf::util::StatusCode error_code) {
+bool ProtoStreamTester::ExpectStatusEq(
+    google::protobuf::util::StatusCode error_code) {
   if (error_code != stream_.Status().code()) {
     ADD_FAILURE()
         << "ObjectTranslatorTest::ValidateStatus: Status doesn't match "
            "expected: "
-        << static_cast<int>(error_code) << " actual: " << static_cast<int>(stream_.Status().code()) << " - "
+        << static_cast<int>(error_code)
+        << " actual: " << static_cast<int>(stream_.Status().code()) << " - "
         << stream_.Status().message() << std::endl;
     return false;
   }

--- a/test/request_weaver_test.cc
+++ b/test/request_weaver_test.cc
@@ -24,9 +24,9 @@
 #include "absl/strings/str_split.h"
 #include "absl/strings/string_view.h"
 
-#include "grpc_transcoding/status_error_listener.h"
 #include "google/protobuf/type.pb.h"
 #include "google/protobuf/util/internal/expecting_objectwriter.h"
+#include "grpc_transcoding/status_error_listener.h"
 #include "gtest/gtest.h"
 
 namespace google {
@@ -57,11 +57,8 @@ class RequestWeaverTest : public ::testing::Test {
   }
 
   std::unique_ptr<RequestWeaver> Create(bool report_collisions) {
-    return std::unique_ptr<RequestWeaver>(
-        new RequestWeaver(std::move(bindings_),
-                          &mock_,
-                          &error_listener_,
-                          report_collisions));
+    return std::unique_ptr<RequestWeaver>(new RequestWeaver(
+        std::move(bindings_), &mock_, &error_listener_, report_collisions));
   }
 
   google::protobuf::util::converter::MockObjectWriter mock_;
@@ -485,10 +482,9 @@ TEST_F(RequestWeaverTest, CollisionReportedInvalidBinding) {
       HasSubstr(
           "Failed to convert binding value int32_field:\"abc\" to int32"));
   w->RenderUint32("uint32_field", 3);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("Failed to convert binding value "
-                "uint32_field:\"abc\" to uint32"));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("Failed to convert binding value "
+                        "uint32_field:\"abc\" to uint32"));
   w->RenderInt64("int64_field", -3);
   EXPECT_THAT(
       w->Status().ToString(),
@@ -606,35 +602,29 @@ TEST_F(RequestWeaverTest, CollisionReported) {
   w->RenderBool("bool_field", false);
   EXPECT_EQ(w->Status().code(),
             google::protobuf::util::StatusCode::kInvalidArgument);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"true\" of the field bool_field is "
-                "conflicting with the value false in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"true\" of the field bool_field is "
+                        "conflicting with the value false in the body."));
   w->RenderInt32("int32_field", -3);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"-2\" of the field int32_field is "
-                "conflicting with the value -3 in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"-2\" of the field int32_field is "
+                        "conflicting with the value -3 in the body."));
   w->RenderUint32("uint32_field", 3);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"2\" of the field uint32_field is "
-                "conflicting with the value 3 in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"2\" of the field uint32_field is "
+                        "conflicting with the value 3 in the body."));
   w->RenderInt64("int64_field", -3);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"-2\" of the field int64_field is "
-                "conflicting with the value -3 in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"-2\" of the field int64_field is "
+                        "conflicting with the value -3 in the body."));
   w->RenderUint64("uint64_field", 3);
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"2\" of the field uint64_field is "
-                "conflicting with the value 3 in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"2\" of the field uint64_field is "
+                        "conflicting with the value 3 in the body."));
   w->RenderString("string_field", "b");
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"a\" of the field string_field is "
-                "conflicting with the value \"b\" in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"a\" of the field string_field is "
+                        "conflicting with the value \"b\" in the body."));
   w->RenderFloat("float_field", 1.0001);
   EXPECT_THAT(
       w->Status().ToString(),
@@ -646,10 +636,9 @@ TEST_F(RequestWeaverTest, CollisionReported) {
       HasSubstr("The binding value \"1.01\" of the field double_field is "
                 "conflicting with the value 1.0001 in the body."));
   w->RenderBytes("bytes_field", "c");
-  EXPECT_THAT(
-      w->Status().ToString(),
-      HasSubstr("The binding value \"a\" of the field bytes_field is "
-                "conflicting with the value \"c\" in the body."));
+  EXPECT_THAT(w->Status().ToString(),
+              HasSubstr("The binding value \"a\" of the field bytes_field is "
+                        "conflicting with the value \"c\" in the body."));
   w->StartObject("B");
   w->RenderBool("B_bool_field", false);
   EXPECT_THAT(

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -866,8 +866,7 @@ TEST_F(ResponseToJsonTranslatorTest, InvalidFrameFlag) {
   std::string actual;
   EXPECT_FALSE(translator.NextMessage(&actual));
   EXPECT_FALSE(translator.Status().ok());
-  EXPECT_EQ(translator.Status().message(),
-            "Unsupported gRPC frame flag: 10");
+  EXPECT_EQ(translator.Status().message(), "Unsupported gRPC frame flag: 10");
 }
 
 TEST_F(ResponseToJsonTranslatorTest, IncompleteFrame) {

--- a/test/status_error_listener_test.cc
+++ b/test/status_error_listener_test.cc
@@ -1,8 +1,8 @@
 #include "grpc_transcoding/status_error_listener.h"
 
+#include "gmock/gmock.h"
 #include "google/protobuf/util/internal/object_location_tracker.h"
 #include "gtest/gtest.h"
-#include "gmock/gmock.h"
 
 namespace google {
 namespace grpc {
@@ -24,8 +24,7 @@ class StatusErrorListenerTest : public ::testing::Test {
 };
 
 TEST_F(StatusErrorListenerTest, ReportFailures) {
-  listener_.set_status(
-      Status(StatusCode::kInvalidArgument, "invalid args"));
+  listener_.set_status(Status(StatusCode::kInvalidArgument, "invalid args"));
   EXPECT_EQ(listener_.status().code(), StatusCode::kInvalidArgument);
   EXPECT_THAT(listener_.status().ToString(), HasSubstr("invalid args"));
 

--- a/test/type_helper_test.cc
+++ b/test/type_helper_test.cc
@@ -342,12 +342,14 @@ TEST_F(ServiceConfigBasedTypeHelperTest, ResolveFieldEncodedPathTests) {
   // json_name = "search%5Bencoded%5D", "search[encode]" should fail
   EXPECT_FALSE(ResolveFieldPath("SearchShelf", "search[encoded]", &field_path));
 
-  EXPECT_TRUE(ResolveFieldPath("SearchShelf", "search%5Bencoded%5D", &field_path));
+  EXPECT_TRUE(
+      ResolveFieldPath("SearchShelf", "search%5Bencoded%5D", &field_path));
   ASSERT_EQ(1, field_path.size());
   EXPECT_EQ("search_encoded", field_path[0]->name());
 
   // json_name = "search[decoded]", "search%5Bdecoded%5D" should work
-  EXPECT_TRUE(ResolveFieldPath("SearchShelf", "search%5Bdecoded%5D", &field_path));
+  EXPECT_TRUE(
+      ResolveFieldPath("SearchShelf", "search%5Bdecoded%5D", &field_path));
   ASSERT_EQ(1, field_path.size());
   EXPECT_EQ("search_decoded", field_path[0]->name());
 


### PR DESCRIPTION
Signed-off-by: Wayne Zhang <qiwzhang@google.com>

Notes:
* Original "http" doesn't work any more.  need to use "https"
* Keep using the old 3.8.0.  The latest clang-format versions pre-build binaries are in github, requires some redirection or permission, did not figure out how to download them in curl.

