### PR TITLE
Fix Struct proto service config in unit tests

### DIFF
--- a/test/json_request_translator_test.cc
+++ b/test/json_request_translator_test.cc
@@ -391,6 +391,49 @@ TEST_F(JsonRequestTranslatorTest, ScalarBody) {
   EXPECT_TRUE((RunTest<Shelf>(3, 0.1, &tc)));
 }
 
+TEST_F(JsonRequestTranslatorTest, StructValueFlat) {
+  LoadService("bookstore_service.pb.txt");
+  SetMessageType("google.protobuf.Struct");
+  TranslationTestCase tc(false);
+  tc.AddMessage(
+      R"({"payload" : "Hello World!"})",
+      R"(
+        fields {
+          key: "payload"
+          value { string_value: "Hello World!" }
+        })");
+  tc.Build();
+
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(1, 1.0, &tc)));
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(2, 1.0, &tc)));
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(3, 0.1, &tc)));
+}
+
+TEST_F(JsonRequestTranslatorTest, StructValueNested) {
+  LoadService("bookstore_service.pb.txt");
+  SetMessageType("google.protobuf.Struct");
+  TranslationTestCase tc(false);
+  tc.AddMessage(
+      R"({"nested" : {"payload" : "Hello World!"}})",
+      R"(
+        fields {
+          key: "nested"
+          value {
+            struct_value: {
+              fields {
+                key: "payload"
+                value { string_value: "Hello World!" }
+              }
+            }
+          }
+        })");
+  tc.Build();
+
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(1, 1.0, &tc)));
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(2, 1.0, &tc)));
+  EXPECT_TRUE((RunTest<::google::protobuf::Struct>(3, 0.1, &tc)));
+}
+
 TEST_F(JsonRequestTranslatorTest, Empty) {
   LoadService("bookstore_service.pb.txt");
   SetMessageType("Shelf");

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -90,7 +90,7 @@ class ResponseToJsonTranslatorTestRun {
     // While we still have expected messages before or at the current position
     // try to match.
     while (next_expected_ != std::end(expected_) &&
-        next_expected_->at <= position_) {
+           next_expected_->at <= position_) {
       // Check the status first
       if (!translator_->Status().ok()) {
         ADD_FAILURE() << "Error: " << translator_->Status().message()
@@ -306,7 +306,7 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
 
   // Adds a message to be tested and the corresponding expected JSON. Must be
   // used before Build().
-  template<typename MessageType>
+  template <typename MessageType>
   void AddMessage(const std::string& proto_text, std::string expected_json) {
     // Generate a gRPC message and add it to the input
     input_ += GenerateGrpcMessage<MessageType>(proto_text);
@@ -519,7 +519,7 @@ TEST_F(ResponseToJsonTranslatorTest, DifferentSizes) {
   SetMessageType("Shelf");
 
   auto sizes = {1, 2, 3, 4, 5, 6, 10, 12, 100, 128, 256, 1024, 4096, 65537};
-  for (auto size: sizes) {
+  for (auto size : sizes) {
     auto theme = GenerateInput("abcdefgh12345", size);
     AddMessage<Shelf>(R"(name : "1" theme : ")" + theme + R"(")",
                       R"({ "name" : "1",  "theme" : ")" + theme + R"("})");
@@ -678,7 +678,7 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingDifferentSizes) {
   SetStreaming(true);
 
   auto sizes = {1, 2, 3, 4, 5, 6, 10, 12, 100, 128, 256, 1024, 4096, 65537};
-  for (auto size: sizes) {
+  for (auto size : sizes) {
     auto theme = GenerateInput("abcdefgh12345", size);
     AddMessage<Shelf>(R"(name : "1" theme : ")" + theme + R"(")",
                       R"({ "name" : "1",  "theme" : ")" + theme + R"("})");
@@ -963,7 +963,7 @@ TEST_F(ResponseToJsonTranslatorTest, Streaming5KMessages) {
 
   // Check the status
   EXPECT_TRUE(translator.Status().ok())
-            << "Error " << translator.Status().message() << std::endl;
+      << "Error " << translator.Status().message() << std::endl;
 
   // Match the output array
   EXPECT_TRUE(ExpectJsonArrayEq(expected_json_array, actual_json_array));

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -410,7 +410,6 @@ TEST_F(ResponseToJsonTranslatorTest, Nested) {
   EXPECT_TRUE(tc->Test(3, 0.2));
 }
 
-// This test currently would time out
 TEST_F(ResponseToJsonTranslatorTest, StructValueFlat) {
   ASSERT_TRUE(LoadService("bookstore_service.pb.txt"));
   SetMessageType("google.protobuf.Struct");

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -90,7 +90,7 @@ class ResponseToJsonTranslatorTestRun {
     // While we still have expected messages before or at the current position
     // try to match.
     while (next_expected_ != std::end(expected_) &&
-           next_expected_->at <= position_) {
+        next_expected_->at <= position_) {
       // Check the status first
       if (!translator_->Status().ok()) {
         ADD_FAILURE() << "Error: " << translator_->Status().message()
@@ -306,7 +306,7 @@ class ResponseToJsonTranslatorTest : public ::testing::Test {
 
   // Adds a message to be tested and the corresponding expected JSON. Must be
   // used before Build().
-  template <typename MessageType>
+  template<typename MessageType>
   void AddMessage(const std::string& proto_text, std::string expected_json) {
     // Generate a gRPC message and add it to the input
     input_ += GenerateGrpcMessage<MessageType>(proto_text);
@@ -410,6 +410,22 @@ TEST_F(ResponseToJsonTranslatorTest, Nested) {
   EXPECT_TRUE(tc->Test(3, 0.2));
 }
 
+// This test currently would time out
+TEST_F(ResponseToJsonTranslatorTest, Struct) {
+  ASSERT_TRUE(LoadService("bookstore_service.pb.txt"));
+  SetMessageType("google.protobuf.Struct");
+  AddMessage<::google::protobuf::Struct>(
+      R"(
+        fields {
+          key: "payload"
+          value { string_value: "Hello World!" }
+        })",
+      R"({ "payload" : "Hello World!"})");
+
+  auto tc = Build();
+  EXPECT_TRUE(tc->Test(1, 1.0));
+}
+
 TEST_F(ResponseToJsonTranslatorTest, NestedAlwaysPrintPrimitiveFields) {
   ASSERT_TRUE(LoadService("bookstore_service.pb.txt"));
   SetMessageType("Book");
@@ -477,7 +493,7 @@ TEST_F(ResponseToJsonTranslatorTest, DifferentSizes) {
   SetMessageType("Shelf");
 
   auto sizes = {1, 2, 3, 4, 5, 6, 10, 12, 100, 128, 256, 1024, 4096, 65537};
-  for (auto size : sizes) {
+  for (auto size: sizes) {
     auto theme = GenerateInput("abcdefgh12345", size);
     AddMessage<Shelf>(R"(name : "1" theme : ")" + theme + R"(")",
                       R"({ "name" : "1",  "theme" : ")" + theme + R"("})");
@@ -636,7 +652,7 @@ TEST_F(ResponseToJsonTranslatorTest, StreamingDifferentSizes) {
   SetStreaming(true);
 
   auto sizes = {1, 2, 3, 4, 5, 6, 10, 12, 100, 128, 256, 1024, 4096, 65537};
-  for (auto size : sizes) {
+  for (auto size: sizes) {
     auto theme = GenerateInput("abcdefgh12345", size);
     AddMessage<Shelf>(R"(name : "1" theme : ")" + theme + R"(")",
                       R"({ "name" : "1",  "theme" : ")" + theme + R"("})");
@@ -921,7 +937,7 @@ TEST_F(ResponseToJsonTranslatorTest, Streaming5KMessages) {
 
   // Check the status
   EXPECT_TRUE(translator.Status().ok())
-      << "Error " << translator.Status().message() << std::endl;
+            << "Error " << translator.Status().message() << std::endl;
 
   // Match the output array
   EXPECT_TRUE(ExpectJsonArrayEq(expected_json_array, actual_json_array));

--- a/test/response_to_json_translator_test.cc
+++ b/test/response_to_json_translator_test.cc
@@ -411,7 +411,7 @@ TEST_F(ResponseToJsonTranslatorTest, Nested) {
 }
 
 // This test currently would time out
-TEST_F(ResponseToJsonTranslatorTest, Struct) {
+TEST_F(ResponseToJsonTranslatorTest, StructValueFlat) {
   ASSERT_TRUE(LoadService("bookstore_service.pb.txt"));
   SetMessageType("google.protobuf.Struct");
   AddMessage<::google::protobuf::Struct>(
@@ -420,10 +420,36 @@ TEST_F(ResponseToJsonTranslatorTest, Struct) {
           key: "payload"
           value { string_value: "Hello World!" }
         })",
-      R"({ "payload" : "Hello World!"})");
+      R"({"payload" : "Hello World!"})");
 
   auto tc = Build();
   EXPECT_TRUE(tc->Test(1, 1.0));
+  EXPECT_TRUE(tc->Test(2, 1.0));
+  EXPECT_TRUE(tc->Test(3, 0.2));
+}
+
+TEST_F(ResponseToJsonTranslatorTest, StructValueNested) {
+  ASSERT_TRUE(LoadService("bookstore_service.pb.txt"));
+  SetMessageType("google.protobuf.Struct");
+  AddMessage<::google::protobuf::Struct>(
+      R"(
+        fields {
+          key: "nested"
+          value {
+            struct_value: {
+              fields {
+                key: "payload"
+                value { string_value: "Hello World!" }
+              }
+            }
+          }
+        })",
+      R"({"nested" : {"payload" : "Hello World!"}})");
+
+  auto tc = Build();
+  EXPECT_TRUE(tc->Test(1, 1.0));
+  EXPECT_TRUE(tc->Test(2, 1.0));
+  EXPECT_TRUE(tc->Test(3, 0.2));
 }
 
 TEST_F(ResponseToJsonTranslatorTest, NestedAlwaysPrintPrimitiveFields) {

--- a/test/testdata/bookstore_service.pb.txt
+++ b/test/testdata/bookstore_service.pb.txt
@@ -374,6 +374,13 @@ types {
     type_url: "type.googleapis.com/google.protobuf.Value"
     json_name: "value"
   }
+  options {
+    name: "map_entry"
+    value {
+      type_url: "type.googleapis.com/google.protobuf.BoolValue"
+      value: ""
+    }
+  }
   source_context {
     file_name: "struct.proto"
   }
@@ -433,6 +440,19 @@ types {
   }
   source_context {
     file_name: "struct.proto"
+  }
+}
+types {
+  name: "google.protobuf.BoolValue"
+  fields {
+    kind: TYPE_BOOL
+    cardinality: CARDINALITY_REQUIRED
+    number: 1
+    name: "value"
+    json_name: "value"
+  }
+  source_context {
+    file_name: "wrappers.proto"
   }
 }
 enums {


### PR DESCRIPTION
## Original Problem
The service config for Struct proto is incomplete as it's missing `map_entry` option in the `google.protobuf.Struct.FieldsEntry` type. This causes the protobuf parsing logic to run infinitely. The parser always assumes Struct has a map typed field, and it will [loop until it finds a map entry field](https://github.com/protocolbuffers/protobuf/blob/0264866ce665911787ba5ca0faf07a5efe2899dd/src/google/protobuf/util/internal/protostream_objectsource.cc#L516). When there's no `map_entry` field set, the field cannot be recognized as Map type, so the loop will go on forever by checking the same field again and again.

## Solution
We just need to add in the `map_entry` option in the textproto.
Note the value field - the value is a bytes typed proto field, and it needs to contain the serialized value for BoolValue.value. When BoolValue.value == true, the serialized value is the char 0x01 which is the control character `^A` (`value: ""`). 
```
    value {
      type_url: "type.googleapis.com/google.protobuf.BoolValue"
      value: ""
    }
```