### PR TITLE
Bump rules_fuzzing dependency to version 0.3.2

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,9 +31,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "rules_fuzzing",
-    sha256 = "a5734cb42b1b69395c57e0bbd32ade394d5c3d6afbfe782b24816a96da24660d",
-    strip_prefix = "rules_fuzzing-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.1.1.zip"],
+    sha256 = "d9002dd3cd6437017f08593124fdd1b13b3473c7b929ceb0e60d317cb9346118",
+    strip_prefix = "rules_fuzzing-0.3.2",
+    urls = ["https://github.com/bazelbuild/rules_fuzzing/archive/v0.3.2.zip"],
 )
 
 load("@rules_fuzzing//fuzzing:repositories.bzl", "rules_fuzzing_dependencies")


### PR DESCRIPTION
# Original Problem
When running `bazel test //test/...:all`, we'd see
```
ERROR: /usr/local/google/home/hongrux/.cache/bazel/_bazel_hongrux/c04ce887a8f743e196d4d0f4e5cc2f31/external/fuzzing_py_deps/pypi__absl_py/BUILD:5:11: no such package '@fuzzing_py_deps//pypi__enum34': BUILD file not found in directory 'pypi__enum34' of external repository @fuzzing_py_deps. Add a BUILD file to a directory to mark it as a package. and referenced by '@fuzzing_py_deps//pypi__absl_py:pypi__absl_py'
ERROR: Analysis of target '//test:message_reader_fuzz_test_corpus' failed; build aborted: Analysis failed
INFO: Elapsed time: 3.773s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (29 packages loaded, 1022 targets configured)
ERROR: Couldn't start the build. Unable to run tests
INFO: Build Event Protocol files produced successfully.
FAILED: Build did NOT complete successfully (29 packages loaded, 1022 targets configured)
FAILED: Build did NOT complete successfully (29 packages loaded, 1022 targets configured)
```

# Solution
The [newest release of rules_fuzzing](https://github.com/bazelbuild/rules_fuzzing/releases/tag/v0.3.2) has the fix from https://github.com/bazelbuild/rules_fuzzing/issues/207. We just need to bump the dependency version up.

Although some people [were still seeing this issue](https://github.com/bazelbuild/rules_fuzzing/issues/207#issuecomment-1229206963) after the library upgrade, I confirmed it does fix this issue for us by running on my machine.

