### PR TITLE
Add benchmarks for variable bindings

### DIFF
--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -62,6 +62,7 @@ cc_library(
     srcs = ["utils.cc"],
     hdrs = ["utils.h"],
     deps = [
+        "//src:type_helper",
         "@com_github_nlohmann_json//:json",
         "@com_google_absl//absl/random",
         "@com_google_absl//absl/status",

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -68,6 +68,7 @@ cc_library(
         "@com_google_absl//absl/status:statusor",
         "@com_google_absl//absl/strings",
         "@com_google_googleapis//google/api:service_cc_proto",
+        "@com_google_protobuf//:protobuf",
     ],
 )
 

--- a/perf_benchmark/benchmark.proto
+++ b/perf_benchmark/benchmark.proto
@@ -64,6 +64,13 @@ service Benchmark {
       body: "*"
     };
   }
+  rpc MultiStringFieldPayloadBM(MultiStringFieldPayload)
+      returns (MultiStringFieldPayload) {
+    option (google.api.http) = {
+      post: "/payload/multi_string_field",
+      body: "*"
+    };
+  }
 }
 
 message BytesPayload {
@@ -89,4 +96,15 @@ message StringArrayPayload {
 message NestedPayload {
   optional NestedPayload nested = 1;
   optional string payload = 2;
+}
+
+message MultiStringFieldPayload {
+  optional string f1 = 1;
+  optional string f2 = 2;
+  optional string f3 = 3;
+  optional string f4 = 4;
+  optional string f5 = 5;
+  optional string f6 = 6;
+  optional string f7 = 7;
+  optional string f8 = 8;
 }

--- a/perf_benchmark/benchmark_service.textproto
+++ b/perf_benchmark/benchmark_service.textproto
@@ -35,6 +35,11 @@ apis {
     request_type_url: "type.googleapis.com/google.protobuf.Struct"
     response_type_url: "type.googleapis.com/google.protobuf.Struct"
   }
+  methods {
+    name: "MultiStringFieldPayloadBM"
+    request_type_url: "type.googleapis.com/MultiStringFieldPayload"
+    response_type_url: "type.googleapis.com/MultiStringFieldPayload"
+  }
 }
 types {
   name: "BytesPayload"
@@ -112,6 +117,67 @@ types {
     number: 2
     name: "payload"
     json_name: "payload"
+  }
+  source_context {
+  }
+}
+types {
+  name: "MultiStringFieldPayload"
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 1
+    name: "f1"
+    json_name: "f1"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 2
+    name: "f2"
+    json_name: "f2"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 3
+    name: "f3"
+    json_name: "f3"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 4
+    name: "f4"
+    json_name: "f4"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 5
+    name: "f5"
+    json_name: "f5"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 6
+    name: "f6"
+    json_name: "f6"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 7
+    name: "f7"
+    json_name: "f7"
+  }
+  fields {
+    kind: TYPE_STRING
+    cardinality: CARDINALITY_OPTIONAL
+    number: 8
+    name: "f8"
+    json_name: "f8"
   }
   source_context {
   }

--- a/perf_benchmark/utils.cc
+++ b/perf_benchmark/utils.cc
@@ -195,6 +195,7 @@ std::vector<const google::protobuf::Field*> ParseFieldPath(
   }
   return field_path;
 }
+
 std::string GenerateMultiStringFieldPayloadJsonStr(
     uint64_t num_fields_exist, absl::string_view field_prefix,
     absl::string_view val) {

--- a/perf_benchmark/utils.h
+++ b/perf_benchmark/utils.h
@@ -22,6 +22,7 @@
 #include "absl/status/status.h"
 #include "absl/strings/string_view.h"
 #include "google/api/service.pb.h"
+#include "google/protobuf/util/internal/type_info.h"
 
 namespace google {
 namespace grpc {
@@ -80,6 +81,14 @@ std::string GetNestedJsonString(uint64_t layers,
 // for stream_size == 1 -> "[json_msg]"
 // for stream_size > 1 -> "[json_msg,...,json_msg]"
 std::string GetStreamedJson(absl::string_view json_msg, uint64_t stream_size);
+
+// Modified based on test/request_translator_test_base.cc.
+// Parse a dot delimited field path string into a vector of actual field
+// pointers.
+std::vector<const google::protobuf::Field*> ParseFieldPath(
+    const google::protobuf::Type& type,
+    google::protobuf::util::converter::TypeInfo& type_info,
+    const std::string& field_path_str);
 
 }  // namespace perf_benchmark
 

--- a/perf_benchmark/utils.h
+++ b/perf_benchmark/utils.h
@@ -23,6 +23,7 @@
 #include "absl/strings/string_view.h"
 #include "google/api/service.pb.h"
 #include "google/protobuf/util/internal/type_info.h"
+#include "src/include/grpc_transcoding/type_helper.h"
 
 namespace google {
 namespace grpc {
@@ -82,13 +83,18 @@ std::string GetNestedJsonString(uint64_t layers,
 // for stream_size > 1 -> "[json_msg,...,json_msg]"
 std::string GetStreamedJson(absl::string_view json_msg, uint64_t stream_size);
 
-// Modified based on test/request_translator_test_base.cc.
 // Parse a dot delimited field path string into a vector of actual field
 // pointers.
 std::vector<const google::protobuf::Field*> ParseFieldPath(
-    const google::protobuf::Type& type,
-    google::protobuf::util::converter::TypeInfo& type_info,
+    const TypeHelper& type_helper, absl::string_view msg_type,
     const std::string& field_path_str);
+
+// Generate a JSON string corresponds to MultiStringFieldMessage.
+// For the 8 fields in the message, we will fill in the first `num_fields_exist`
+// number of fields with the given `val`.
+std::string GenerateMultiStringFieldPayloadJsonStr(
+    uint64_t num_fields_exist, absl::string_view field_prefix,
+    absl::string_view val);
 
 }  // namespace perf_benchmark
 


### PR DESCRIPTION
## Benchmark variables added
- Variable binding depth
- Number of variable bindings

## Local benchmark results
This is a quick run with only one repetition of the benchmarks. Detailed results and analysis will be added to the README in a separate PR.
At a glance, having variable bindings would make the transcoding quicker. However, the benchmark doesn't account for the time to parse the bindings from the URI as we are just benchmarking for the transcoding process.
```
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                    Time             CPU   Iterations byte_latency byte_throughput message_latency message_throughput request_latency request_throughput
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
BM_NestedProtoPayloadFromJsonNonStreaming/0              14232 ns        14221 ns        50249    492.573ns      2.07888M/s       14.2211us         70.3181k/s       14.2211us         70.3181k/s
BM_NestedProtoPayloadFromJsonNonStreaming/1              29451 ns        29421 ns        24164    752.165ns       1.3614M/s       29.4213us         33.9889k/s       29.4213us         33.9889k/s
BM_NestedProtoPayloadFromJsonNonStreaming/8              62635 ns        61994 ns        11511    559.373ns      1.83062M/s       61.9938us         16.1306k/s       61.9938us         16.1306k/s
BM_NestedProtoPayloadFromJsonNonStreaming/32            189859 ns       189365 ns         3701    530.885ns      1.92885M/s       189.365us         5.28081k/s       189.365us         5.28081k/s
BM_NestedVariableBindingsFromJsonNonStreaming/0          18825 ns        18811 ns        36912     651.55ns      1.57164M/s       18.8109us         53.1607k/s       18.8109us         53.1607k/s
BM_NestedVariableBindingsFromJsonNonStreaming/1          37193 ns        36915 ns        18898    943.732ns       1111.1k/s       36.9146us         27.0896k/s       36.9146us         27.0896k/s
BM_NestedVariableBindingsFromJsonNonStreaming/8          74400 ns        74294 ns         9443    670.355ns      1.52755M/s       74.2937us         13.4601k/s       74.2937us         13.4601k/s
BM_NestedVariableBindingsFromJsonNonStreaming/32        219952 ns       219795 ns         3150    616.195ns      1.66181M/s       219.795us          4.5497k/s       219.795us          4.5497k/s
BM_NumVariableBindingsPayloadFromJsonNonStreaming/0  201216141 ns    201116629 ns            3    25.7422ns      39.7791M/s       0.201117s          4.97224/s       0.201117s          4.97224/s
BM_NumVariableBindingsPayloadFromJsonNonStreaming/2  209142844 ns    208315732 ns            3    26.6636ns      38.4043M/s       0.208316s          4.80041/s       0.208316s          4.80041/s
BM_NumVariableBindingsPayloadFromJsonNonStreaming/4  223893325 ns    223451770 ns            3     28.601ns      35.8029M/s       0.223452s          4.47524/s       0.223452s          4.47524/s
BM_NumVariableBindingsPayloadFromJsonNonStreaming/8  240567207 ns    239983385 ns            3     30.717ns      33.3366M/s       0.239983s          4.16696/s       0.239983s          4.16696/s
```