### PR TITLE
Add Bazel rules to package performance benchmark binary into a Docker image

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -56,3 +56,6 @@ build:asan-replay --@rules_fuzzing//fuzzing:cc_engine_sanitizer=asan
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine=@rules_fuzzing_oss_fuzz//:oss_fuzz_engine
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_instrumentation=oss-fuzz
 build:oss-fuzz --@rules_fuzzing//fuzzing:cc_engine_sanitizer=none
+
+# Default build parameters so that `bazel build //...` can always find them.
+build --define=PUSH_REGISTRY=gcr.io --define=PUSH_PROJECT=project-id --define=PUSH_TAG=latest

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,6 +21,7 @@ load(
     "googleapis_repositories",
     "googlebenchmark_repositories",
     "googletest_repositories",
+    "io_bazel_rules_docker",
     "nlohmannjson_repositories",
     "protobuf_repositories",
 )
@@ -57,6 +58,26 @@ googleapis_repositories()
 googlebenchmark_repositories()
 
 nlohmannjson_repositories()
+
+# Followed https://github.com/bazelbuild/rules_docker#setup and
+# https://github.com/bazelbuild/rules_docker#cc_image.
+# BEGIN io_bazel_rules_docker
+io_bazel_rules_docker()
+
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+load(
+    "@io_bazel_rules_docker//cc:image.bzl",
+    _cc_image_repos = "repositories",
+)
+
+_cc_image_repos()
+# END io_bazel_rules_docker
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -17,6 +17,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push")
 
 cc_proto_library(
     name = "benchmark_cc_proto",
@@ -61,6 +62,15 @@ cc_binary(
 cc_image(
     name = "benchmark_main_image",
     binary = ":benchmark_main",
+)
+
+container_push(
+    name = "benchmark_main_image_push",
+    format = "Docker",
+    image = ":benchmark_main_image",
+    registry = "gcr.io",
+    repository = "$(PUSH_PROJECT)/grpc-httpjson-transcoding-benchmark",
+    tag = "$(PUSH_TAG)",
 )
 
 cc_library(

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -69,12 +69,15 @@ cc_image(
 )
 
 # Example run command:
-# bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_PROJECT=project-id --define=PUSH_TAG=latest
+# bazel run //perf_benchmark:benchmark_main_image_push \
+# --define=PUSH_REGISTRY=gcr.io \
+# --define=PUSH_PROJECT=project-id \
+# --define=PUSH_TAG=latest
 container_push(
     name = "benchmark_main_image_push",
     format = "Docker",
     image = ":benchmark_main_image",
-    registry = "gcr.io",
+    registry = "$(PUSH_REGISTRY)",
     repository = "$(PUSH_PROJECT)/grpc-httpjson-transcoding-benchmark",
     tag = "$(PUSH_TAG)",
 )

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -73,6 +73,7 @@ cc_binary(
 cc_image(
     name = "benchmark_main_image",
     binary = ":benchmark_main",
+    testonly = 1,
 )
 
 # Example run command:
@@ -84,6 +85,7 @@ container_push(
     name = "benchmark_main_image_push",
     format = "Docker",
     image = ":benchmark_main_image",
+    testonly = 1,
     registry = "$(PUSH_REGISTRY)",
     repository = "$(PUSH_PROJECT)/grpc-httpjson-transcoding-benchmark",
     tag = "$(PUSH_TAG)",

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -59,11 +59,17 @@ cc_binary(
     ],
 )
 
+# Note: cc_image rule won't build the binary inside the container. It builds the
+# binary locally and copies the binary into the container.
+# This cc_image rule with v.0.25.0 rules_docker release uses Debian 11 as base.
+# Please make sure if you're building from Debian 11 system as well.
 cc_image(
     name = "benchmark_main_image",
     binary = ":benchmark_main",
 )
 
+# Example run command:
+# bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_PROJECT=project-id --define=PUSH_TAG=latest
 container_push(
     name = "benchmark_main_image_push",
     format = "Docker",

--- a/perf_benchmark/BUILD
+++ b/perf_benchmark/BUILD
@@ -16,6 +16,7 @@
 #
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@io_bazel_rules_docker//cc:image.bzl", "cc_image")
 
 cc_proto_library(
     name = "benchmark_cc_proto",
@@ -55,6 +56,11 @@ cc_binary(
         "@com_google_benchmark//:benchmark_main",
         "@com_google_googleapis//google/api:service_cc_proto",
     ],
+)
+
+cc_image(
+    name = "benchmark_main_image",
+    binary = ":benchmark_main",
 )
 
 cc_library(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -184,3 +184,13 @@ cc_library(
         sha256 = "d69f9deb6a75e2580465c6c4c5111b89c4dc2fa94e3a85fcd2ffcd9a143d9273",
         build_file_content = BUILD,
     )
+
+RULES_DOCKER_COMMIT = "0.25.0"  # Jul 25, 2022
+RULES_DOCKER_SHA256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf"
+
+def io_bazel_rules_docker(bind = True):
+    http_archive(
+        name = "io_bazel_rules_docker",
+        sha256 = RULES_DOCKER_SHA256,
+        urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v" + RULES_DOCKER_COMMIT + "/rules_docker-v" + RULES_DOCKER_COMMIT + ".tar.gz"],
+    )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -185,7 +185,7 @@ cc_library(
         build_file_content = BUILD,
     )
 
-RULES_DOCKER_COMMIT = "0.25.0"  # Jul 25, 2022
+RULES_DOCKER_COMMIT = "0.25.0"  # Jun 22, 2022
 RULES_DOCKER_SHA256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf"
 
 def io_bazel_rules_docker(bind = True):

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -19,6 +19,10 @@
 bazel build //...
 bazel test //... --test_output=errors
 
-# Push benchmark binary image to cloudesf-testing GCR.
+# Authenticate from gcloud using service account credentials.
 gcloud config set core/project cloudesf-testing
+gcloud auth activate-service-account \
+  --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
+
+# Push benchmark binary image to cloudesf-testing GCR.
 bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_REGISTRY=gcr.io --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -18,3 +18,7 @@
 
 bazel build //...
 bazel test //... --test_output=errors
+
+# Push benchmark binary image to cloudesf-testing GCR.
+gcloud config set core/project cloudesf-testing
+bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_REGISTRY=gcr.io --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -19,10 +19,6 @@
 bazel build //...
 bazel test //... --test_output=errors
 
-# Authenticate from gcloud using service account credentials.
-gcloud config set core/project cloudesf-testing
-gcloud auth activate-service-account \
-  --key-file="${GOOGLE_APPLICATION_CREDENTIALS}"
-
 # Push benchmark binary image to cloudesf-testing GCR.
+gcloud config set core/project cloudesf-testing
 bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_REGISTRY=gcr.io --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -18,7 +18,3 @@
 
 bazel build //...
 bazel test //... --test_output=errors
-
-# Push benchmark binary image to cloudesf-testing GCR.
-gcloud config set core/project cloudesf-testing
-bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_REGISTRY=gcr.io --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -18,3 +18,5 @@
 
 bazel build //...
 bazel test //... --test_output=errors
+
+bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -18,5 +18,3 @@
 
 bazel build //...
 bazel test //... --test_output=errors
-
-bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_PROJECT=cloudesf-testing --define=PUSH_TAG=github-latest


### PR DESCRIPTION
I'm not entirely sure if we want to merge this. Having this can be convenient for the community as it will be easier to reproduce our benchmark results by running it in a container.

Two new build targets added:
- Generate and run a docker container that has the benchmark binary
```
bazel run //perf_benchmark:benchmark_main_image
```
- Push the benchmark image to a container registry
```
bazel run //perf_benchmark:benchmark_main_image_push --define=PUSH_REGISTRY=gcr.io \
  --define=PUSH_PROJECT=project-id \
  --define=PUSH_TAG=latest
```

