### PR TITLE
    Remove unnecessary VariableBinding Templatization.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,10 @@
+---
+Language: Cpp
+BasedOnStyle: Google
+---
+Language: Proto
+BasedOnStyle: Google
+---
+Language: TextProto
+BasedOnStyle: Google
+...

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 /bazel-out
 /bazel-testlogs
 
-# CLion bazel plugin
-/.clwb
-# Intellij bazel plugin
-/.ilwb
+# IDE
+.clwb/
+.ijwb/
+.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+CPP_PROTO_FILES = $(shell find . -type f \
+		-regex "./\(src\|api\)/.*[.]\(h\|cc\|proto\)" \
+		-not -path "./vendor/*")
+
+.PHONY: build
+build: clang-format
+	bazelisk build //...
+
+.PHONY: test
+test: clang-format
+	bazelisk test //...
+
+.PHONY: clang-format
+clang-format:
+	@echo "--> formatting code with 'clang-format' tool"
+	@echo $(CPP_PROTO_FILES) | xargs clang-format-14 -i

--- a/src/http_template.cc
+++ b/src/http_template.cc
@@ -14,11 +14,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////////
 //
+#include "grpc_transcoding/http_template.h"
+
 #include <cassert>
 #include <string>
 #include <vector>
-
-#include "grpc_transcoding/http_template.h"
 
 namespace google {
 namespace grpc {

--- a/src/include/grpc_transcoding/http_template.h
+++ b/src/include/grpc_transcoding/http_template.h
@@ -66,6 +66,24 @@ class HttpTemplate {
   std::vector<Variable> variables_;
 };
 
+/**
+ * VariableBinding specifies a value for a single field in the request message.
+ * When transcoding HTTP/REST/JSON to gRPC/proto the request message is
+ * constructed using the HTTP body and the variable bindings (specified through
+ * request url).
+ * See
+ * https://github.com/googleapis/googleapis/blob/master/google/api/http.proto
+ * for details of variable binding.
+ */
+struct VariableBinding {
+  // The location of the field in the protobuf message, where the value
+  // needs to be inserted, e.g. "shelf.theme" would mean the "theme" field
+  // of the nested "shelf" message of the request protobuf message.
+  std::vector<std::string> field_path;
+  // The value to be inserted.
+  std::string value;
+};
+
 }  // namespace transcoding
 }  // namespace grpc
 }  // namespace google

--- a/src/include/grpc_transcoding/internal/protobuf_types.h
+++ b/src/include/grpc_transcoding/internal/protobuf_types.h
@@ -15,7 +15,6 @@
 #ifndef GRPC_TRANSCODING_INTERNAL_PROTOBUF_TYPES_H_
 #define GRPC_TRANSCODING_INTERNAL_PROTOBUF_TYPES_H_
 
-
 namespace google {
 namespace grpc {
 namespace transcoding {

--- a/src/include/grpc_transcoding/message_reader.h
+++ b/src/include/grpc_transcoding/message_reader.h
@@ -17,8 +17,8 @@
 
 #include <memory>
 
-#include "transcoder_input_stream.h"
 #include "absl/status/status.h"
+#include "transcoder_input_stream.h"
 
 namespace google {
 namespace grpc {

--- a/src/include/grpc_transcoding/message_stream.h
+++ b/src/include/grpc_transcoding/message_stream.h
@@ -18,9 +18,9 @@
 #include <memory>
 #include <string>
 
+#include "absl/status/status.h"
 #include "google/protobuf/io/zero_copy_stream.h"
 #include "transcoder_input_stream.h"
-#include "absl/status/status.h"
 
 namespace google {
 namespace grpc {

--- a/src/include/grpc_transcoding/path_matcher.h
+++ b/src/include/grpc_transcoding/path_matcher.h
@@ -22,10 +22,10 @@
 #include <unordered_map>
 #include <unordered_set>
 
+#include "absl/strings/str_split.h"
 #include "http_template.h"
 #include "path_matcher_node.h"
 #include "percent_encoding.h"
-#include "absl/strings/str_split.h"
 
 namespace google {
 namespace grpc {
@@ -56,8 +56,6 @@ class PathMatcher {
  public:
   ~PathMatcher(){};
 
-  // TODO: Do not template VariableBinding
-  template <class VariableBinding>
   Method Lookup(const std::string& http_method, const std::string& path,
                 const std::string& query_params,
                 std::vector<VariableBinding>* variable_bindings,
@@ -173,7 +171,6 @@ class PathMatcherBuilder {
 
 namespace {
 
-template <class VariableBinding>
 void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
                              const std::vector<std::string>& parts,
                              UrlUnescapeSpec unescape_spec,
@@ -210,7 +207,6 @@ void ExtractBindingsFromPath(const std::vector<HttpTemplate::Variable>& vars,
   }
 }
 
-template <class VariableBinding>
 void ExtractBindingsFromQueryParameters(
     const std::string& query_params,
     const std::unordered_set<std::string>& system_params,
@@ -325,7 +321,6 @@ PathMatcher<Method>::PathMatcher(PathMatcherBuilder<Method>&& builder)
 // TODO: cache results by adding get/put methods here (if profiling reveals
 // benefit)
 template <class Method>
-template <class VariableBinding>
 Method PathMatcher<Method>::Lookup(
     const std::string& http_method, const std::string& path,
     const std::string& query_params,

--- a/src/include/grpc_transcoding/percent_encoding.h
+++ b/src/include/grpc_transcoding/percent_encoding.h
@@ -16,6 +16,7 @@
 #define GRPC_TRANSCODING_PERCENT_ENCODING_H_
 
 #include <string>
+
 #include "absl/strings/string_view.h"
 
 namespace google {

--- a/src/include/grpc_transcoding/request_message_translator.h
+++ b/src/include/grpc_transcoding/request_message_translator.h
@@ -118,9 +118,7 @@ class RequestMessageTranslator : public MessageStream {
   // MessageStream methods
   bool NextMessage(std::string* message);
   bool Finished() const;
-  absl::Status Status() const {
-    return error_listener_.status();
-  }
+  absl::Status Status() const { return error_listener_.status(); }
 
  private:
   // Reserves space (5 bytes) for the GRPC delimiter to be written later. As it

--- a/src/include/grpc_transcoding/request_weaver.h
+++ b/src/include/grpc_transcoding/request_weaver.h
@@ -78,9 +78,7 @@ class RequestWeaver : public google::protobuf::util::converter::ObjectWriter {
                 google::protobuf::util::converter::ObjectWriter* ow,
                 StatusErrorListener* el, bool report_collisions);
 
-  absl::Status Status() {
-    return error_listener_->status();
-  }
+  absl::Status Status() { return error_listener_->status(); }
 
   // ObjectWriter methods
   RequestWeaver* StartObject(internal::string_view name);

--- a/src/include/grpc_transcoding/status_error_listener.h
+++ b/src/include/grpc_transcoding/status_error_listener.h
@@ -1,9 +1,9 @@
 #ifndef GRPC_TRANSCODING_STATUS_ERROR_LISTENER_H_
 #define GRPC_TRANSCODING_STATUS_ERROR_LISTENER_H_
 
+#include "absl/status/status.h"
 #include "google/protobuf/util/converter/error_listener.h"
 #include "grpc_transcoding/internal/protobuf_types.h"
-#include "absl/status/status.h"
 
 namespace google {
 namespace grpc {
@@ -39,7 +39,7 @@ class StatusErrorListener
   StatusErrorListener& operator=(const StatusErrorListener&) = delete;
 };
 
-}  // namespace src::include::grpc_transcoding}  // namespace transcoding
+}  // namespace transcoding
 
 }  // namespace grpc
 }  // namespace google

--- a/src/include/grpc_transcoding/type_helper.h
+++ b/src/include/grpc_transcoding/type_helper.h
@@ -15,12 +15,12 @@
 #ifndef GRPC_TRANSCODING_TYPE_HELPER_H_
 #define GRPC_TRANSCODING_TYPE_HELPER_H_
 
+#include <memory>
+#include <vector>
+
 #include "google/protobuf/type.pb.h"
 #include "google/protobuf/util/converter/type_info.h"
 #include "google/protobuf/util/type_resolver.h"
-
-#include <memory>
-#include <vector>
 
 namespace google {
 namespace grpc {
@@ -75,9 +75,8 @@ class TypeHelper {
   void AddType(const ::google::protobuf::Type& t);
   void AddEnum(const ::google::protobuf::Enum& e);
 
-  const google::protobuf::Field* FindField(
-      const google::protobuf::Type* type,
-      absl::string_view name) const;
+  const google::protobuf::Field* FindField(const google::protobuf::Type* type,
+                                           absl::string_view name) const;
 
   ::google::protobuf::util::TypeResolver* type_resolver_;
   std::unique_ptr<::google::protobuf::util::converter::TypeInfo> type_info_;

--- a/src/message_reader.cc
+++ b/src/message_reader.cc
@@ -91,9 +91,8 @@ std::unique_ptr<pbio::ZeroCopyInputStream> MessageReader::NextMessage() {
       // Find out whether the stream is finished and return false.
       finished_ = in_->Finished();
       if (finished_ && in_->BytesAvailable() != 0) {
-        status_ = absl::Status(
-            absl::StatusCode::kInternal,
-            "Incomplete gRPC frame header received");
+        status_ = absl::Status(absl::StatusCode::kInternal,
+                               "Incomplete gRPC frame header received");
       }
       return nullptr;
     }
@@ -121,8 +120,8 @@ std::unique_ptr<pbio::ZeroCopyInputStream> MessageReader::NextMessage() {
       status_ = absl::Status(
           absl::StatusCode::kInternal,
           "Incomplete gRPC frame expected size: " +
-              std::to_string(current_message_size_) + " actual size: " +
-              std::to_string(in_->BytesAvailable()));
+              std::to_string(current_message_size_) +
+              " actual size: " + std::to_string(in_->BytesAvailable()));
     }
     // We don't have a full message
     return nullptr;

--- a/src/request_stream_translator.cc
+++ b/src/request_stream_translator.cc
@@ -67,7 +67,7 @@ RequestStreamTranslator* RequestStreamTranslator::StartObject(
   if (depth_ == 0) {
     // In depth_ == 0 case we expect only StartList()
     status_ = absl::Status(absl::StatusCode::kInvalidArgument,
-                             "Expected an array instead of an object");
+                           "Expected an array instead of an object");
     return this;
   }
   if (depth_ == 1) {
@@ -88,7 +88,7 @@ RequestStreamTranslator* RequestStreamTranslator::EndObject() {
   --depth_;
   if (depth_ < 1) {
     status_ = absl::Status(absl::StatusCode::kInvalidArgument,
-                             "Mismatched end of object.");
+                           "Mismatched end of object.");
     return this;
   }
   translator_->Input().EndObject();
@@ -130,7 +130,7 @@ RequestStreamTranslator* RequestStreamTranslator::EndList() {
   --depth_;
   if (depth_ < 0) {
     status_ = absl::Status(absl::StatusCode::kInvalidArgument,
-                             "Mismatched end of array.");
+                           "Mismatched end of array.");
     return this;
   }
   if (depth_ == 0) {
@@ -266,7 +266,7 @@ void RequestStreamTranslator::RenderData(internal::string_view name,
   if (depth_ == 0) {
     // In depth_ == 0 case we expect only a StartList()
     status_ = absl::Status(absl::StatusCode::kInvalidArgument,
-                             "Expected an array instead of a scalar value.");
+                           "Expected an array instead of a scalar value.");
   } else if (depth_ == 1) {
     // This means we have an array of scalar values. This can happen if the HTTP
     // body is mapped to a scalar field.

--- a/src/request_weaver.cc
+++ b/src/request_weaver.cc
@@ -16,20 +16,20 @@
 //
 #include "grpc_transcoding/request_weaver.h"
 
-#include <string>
-#include <vector>
 #include <float.h>
+
 #include <cmath>
 #include <limits>
+#include <string>
+#include <vector>
 
-#include "absl/strings/str_format.h"
 #include "absl/strings/str_cat.h"
-
-#include "google/protobuf/util/field_comparator.h"
+#include "absl/strings/str_format.h"
 #include "google/protobuf/stubs/strutil.h"
 #include "google/protobuf/type.pb.h"
 #include "google/protobuf/util/converter/datapiece.h"
 #include "google/protobuf/util/converter/object_writer.h"
+#include "google/protobuf/util/field_comparator.h"
 
 namespace google {
 namespace grpc {
@@ -41,24 +41,20 @@ namespace pbconv = google::protobuf::util::converter;
 
 namespace {
 
-
-bool AlmostEquals(float a, float b) {
-  return fabs(a - b) < 32 * FLT_EPSILON;
-}
-
+bool AlmostEquals(float a, float b) { return fabs(a - b) < 32 * FLT_EPSILON; }
 
 absl::Status bindingFailureStatus(internal::string_view field_name,
-                                      internal::string_view type,
-                                      const pbconv::DataPiece& value) {
+                                  internal::string_view type,
+                                  const pbconv::DataPiece& value) {
   return absl::Status(
       absl::StatusCode::kInvalidArgument,
       absl::StrCat("Failed to convert binding value ", field_name, ":",
-                 value.ValueAsStringOrDefault(""), " to ", type));
+                   value.ValueAsStringOrDefault(""), " to ", type));
 }
 
 absl::Status isEqual(internal::string_view field_name,
-                         const pbconv::DataPiece& value_in_body,
-                         const pbconv::DataPiece& value_in_binding) {
+                     const pbconv::DataPiece& value_in_body,
+                     const pbconv::DataPiece& value_in_binding) {
   bool value_is_same = true;
   switch (value_in_body.type()) {
     case pbconv::DataPiece::TYPE_INT32: {
@@ -106,8 +102,7 @@ absl::Status isEqual(internal::string_view field_name,
       if (!status.ok()) {
         return bindingFailureStatus(field_name, "double", value_in_binding);
       }
-      if (!AlmostEquals(
-              status.value(), value_in_body.ToDouble().value())) {
+      if (!AlmostEquals(status.value(), value_in_body.ToDouble().value())) {
         value_is_same = false;
       }
       break;
@@ -117,8 +112,7 @@ absl::Status isEqual(internal::string_view field_name,
       if (!status.ok()) {
         return bindingFailureStatus(field_name, "float", value_in_binding);
       }
-      if (!AlmostEquals(status.value(),
-                                             value_in_body.ToFloat().value())) {
+      if (!AlmostEquals(status.value(), value_in_body.ToFloat().value())) {
         value_is_same = false;
       }
       break;

--- a/src/response_to_json_translator.cc
+++ b/src/response_to_json_translator.cc
@@ -108,9 +108,8 @@ bool ResponseToJsonTranslator::TranslateMessage(
       // message, so prepend the
       // output JSON with a '['.
       if (!WriteChar(&json_stream, '[')) {
-        status_ = absl::Status(
-            absl::StatusCode::kInternal,
-            "Failed to build the response message.");
+        status_ = absl::Status(absl::StatusCode::kInternal,
+                               "Failed to build the response message.");
         return false;
       }
       first_ = false;
@@ -118,9 +117,8 @@ bool ResponseToJsonTranslator::TranslateMessage(
       // For non-newline-delimited streaming calls add a ',' before each message
       // except the first.
       if (!WriteChar(&json_stream, ',')) {
-        status_ = absl::Status(
-            absl::StatusCode::kInternal,
-            "Failed to build the response message.");
+        status_ = absl::Status(absl::StatusCode::kInternal,
+                               "Failed to build the response message.");
         return false;
       }
     }
@@ -138,9 +136,8 @@ bool ResponseToJsonTranslator::TranslateMessage(
   // Append a newline delimiter after the message if needed.
   if (streaming_ && options_.stream_newline_delimited) {
     if (!WriteChar(&json_stream, '\n')) {
-      status_ = absl::Status(
-          absl::StatusCode::kInternal,
-          "Failed to build the response message.");
+      status_ = absl::Status(absl::StatusCode::kInternal,
+                             "Failed to build the response message.");
       return false;
     }
   }

--- a/src/status_error_listener.cc
+++ b/src/status_error_listener.cc
@@ -2,7 +2,6 @@
 
 #include <string>
 
-
 namespace google {
 namespace grpc {
 
@@ -11,18 +10,17 @@ namespace transcoding {
 void StatusErrorListener::InvalidName(
     const ::google::protobuf::util::converter::LocationTrackerInterface& loc,
     internal::string_view unknown_name, internal::string_view message) {
-  status_ = absl::Status(
-      absl::StatusCode::kInvalidArgument,
-      loc.ToString() + ": " + std::string(message));
+  status_ = absl::Status(absl::StatusCode::kInvalidArgument,
+                         loc.ToString() + ": " + std::string(message));
 }
 
 void StatusErrorListener::InvalidValue(
     const ::google::protobuf::util::converter::LocationTrackerInterface& loc,
     internal::string_view type_name, internal::string_view value) {
-  status_ = absl::Status(
-      absl::StatusCode::kInvalidArgument,
-      loc.ToString() + ": invalid value " + std::string(value) + " for type " +
-          std::string(type_name));
+  status_ =
+      absl::Status(absl::StatusCode::kInvalidArgument,
+                   loc.ToString() + ": invalid value " + std::string(value) +
+                       " for type " + std::string(type_name));
 }
 
 void StatusErrorListener::MissingField(
@@ -33,7 +31,7 @@ void StatusErrorListener::MissingField(
       loc.ToString() + ": missing field " + std::string(missing_name));
 }
 
-}  // namespace src::include::grpc_transcoding}  // namespace transcoding
+}  // namespace transcoding
 
 }  // namespace grpc
 }  // namespace google

--- a/src/type_helper.cc
+++ b/src/type_helper.cc
@@ -65,7 +65,7 @@ class SimpleTypeResolver : public pbutil::TypeResolver {
       return absl::Status();
     } else {
       return absl::Status(absl::StatusCode::kNotFound,
-                            "Type '" + type_url + "' cannot be found.");
+                          "Type '" + type_url + "' cannot be found.");
     }
   }
 
@@ -80,7 +80,7 @@ class SimpleTypeResolver : public pbutil::TypeResolver {
       return absl::Status();
     } else {
       return absl::Status(absl::StatusCode::kNotFound,
-                            "Enum '" + type_url + "' cannot be found.");
+                          "Enum '" + type_url + "' cannot be found.");
     }
   }
 
@@ -184,8 +184,7 @@ absl::Status TypeHelper::ResolveFieldPath(
 }
 
 const google::protobuf::Field* TypeHelper::FindField(
-    const google::protobuf::Type* type,
-    absl::string_view name) const {
+    const google::protobuf::Type* type, absl::string_view name) const {
   auto* field = Info()->FindField(type, name);
   if (field != nullptr) {
     return field;
@@ -214,9 +213,9 @@ absl::Status TypeHelper::ResolveFieldPath(
     auto field = FindField(current_type, field_names[i]);
     if (nullptr == field) {
       return absl::Status(absl::StatusCode::kInvalidArgument,
-                            "Could not find field \"" + field_names[i] +
-                                "\" in the type \"" + current_type->name() +
-                                "\".");
+                          "Could not find field \"" + field_names[i] +
+                              "\" in the type \"" + current_type->name() +
+                              "\".");
     }
     field_path.push_back(field);
 
@@ -233,8 +232,8 @@ absl::Status TypeHelper::ResolveFieldPath(
       current_type = Info()->GetTypeByTypeUrl(field->type_url());
       if (nullptr == current_type) {
         return absl::Status(absl::StatusCode::kInvalidArgument,
-                              "Cannot find the type \"" + field->type_url() +
-                                  "\" while parsing a field path.");
+                            "Cannot find the type \"" + field->type_url() +
+                                "\" while parsing a field path.");
       }
     }
   }


### PR DESCRIPTION
    VariableBinding is a first class concept for path matcher and doesn't
    need to be templated.

    In addition, add a few developer tools.
    * Clang format
    * Makefile